### PR TITLE
Add fixed-k version of the NFW fitter

### DIFF
--- a/diffprof/fit_nfw_helpers_fixed_k.py
+++ b/diffprof/fit_nfw_helpers_fixed_k.py
@@ -1,0 +1,232 @@
+"""Helper functions for fitting NFW concentration histories of individual halos."""
+import warnings
+import numpy as np
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import value_and_grad, grad
+from jax import vmap as jvmap
+from jax.experimental import optimizers as jax_opt
+from scipy.optimize import curve_fit
+from .nfw_evolution import u_lgc_vs_lgt, DEFAULT_CONC_PARAMS
+from .nfw_evolution import get_unbounded_params, _get_u_k, get_bounded_params
+
+T_FIT_MIN = 2.0
+FIXED_K = 4.0
+FIXED_U_K = _get_u_k(FIXED_K)
+
+
+@jjit
+def u_lgc_vs_lgt_fixed_k(lgt, u_conc_lgtc, u_conc_beta_early, u_conc_beta_late):
+    return u_lgc_vs_lgt(
+        lgt, u_conc_lgtc, FIXED_U_K, u_conc_beta_early, u_conc_beta_late
+    )
+
+
+_a = (0, None, None, None)
+_jac_func = jjit(jvmap(grad(u_lgc_vs_lgt_fixed_k, argnums=(1, 2, 3)), in_axes=_a))
+
+
+@jjit
+def get_bounded_params_fixed_k(up):
+    up_all = (up[0], FIXED_U_K, *up[1:])
+    return get_bounded_params(up_all)
+
+
+def fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, n_step=300, t_fit_min=T_FIT_MIN):
+    """Identify best-fitting parameters for the input concentration history.
+
+    Parameters
+    ----------
+    t_sim : ndarray of shape (n_sim, )
+        Age of the universe in Gyr
+
+    conc_sim : ndarray of shape (n_sim, )
+        NFW concentration of the simulated halo
+
+    log_mah_sim : ndarray of shape (n_sim, )
+        Base-10 log of the mass of the simulated halo in Msun.
+        When halo mass falls below lgm_min,
+        the corresponding values of conc_sim will be ignored.
+
+    lgm_min : float
+        Cutoff mass used to define the target data
+
+    nstep : int, optional
+        Number of gradient descent steps to take when fitting concentration with the
+        fallback algorithm when scipy.optimize.curve_fit fails.
+
+    Returns
+    -------
+    p_best : ndarray of shape (n_params, )
+        Best-fitting parameters
+
+    loss : float
+        value of MSE loss for the best-fitting parameters
+
+    method : int
+        0 for scipy.optimize.curve_fit
+        1 for jax.adam
+        -1 for halos with outlier histories that cannot be fit by the model
+
+    loss_data : two-element sequence of u_params, loss_data
+
+    """
+    u_p0, loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min)
+    t, lgc, msk = loss_data
+
+    if len(lgc) < 10:
+        method = -1
+        p_best = np.nan
+        loss = np.nan
+        return p_best, loss, method, loss_data
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        try:
+            u_p = curve_fit(u_lgc_vs_lgt_fixed_k, t, lgc, p0=u_p0, jac=jac_lgc)[0]
+            method = 0
+            p_best = get_bounded_params_fixed_k(u_p)
+            loss = log_conc_mse_loss(u_p, loss_data)
+        except RuntimeError:
+            res = jax_adam_wrapper(log_conc_mse_loss_and_grads, u_p0, loss_data, n_step)
+            u_p = res[0]
+            if ~np.all(np.isfinite(u_p)):
+                method = -1
+                p_best = np.nan
+                loss = np.nan
+            else:
+                method = 1
+                p_best = get_bounded_params_fixed_k(u_p)
+                loss = log_conc_mse_loss(u_p, loss_data)
+    return p_best, loss, method, loss_data
+
+
+def jac_lgc(t, u_conc_lgtc, u_conc_beta_early, u_conc_beta_late):
+    grads = _jac_func(t, u_conc_lgtc, u_conc_beta_early, u_conc_beta_late)
+    return np.array(grads).T
+
+
+@jjit
+def log_conc_mse_loss(u_params, loss_data):
+    """MSE loss function for fitting individual halo growth."""
+    lgt_target, log_conc_target, msk = loss_data
+    u_conc_lgtc, u_conc_beta_early, u_conc_beta_late = u_params
+    log_conc_pred = u_lgc_vs_lgt_fixed_k(
+        lgt_target, u_conc_lgtc, u_conc_beta_early, u_conc_beta_late
+    )
+    log_conc_loss = _mse(log_conc_pred, log_conc_target)
+    return log_conc_loss
+
+
+@jjit
+def log_conc_mse_loss_and_grads(u_params, loss_data):
+    """MSE loss and grad function for fitting individual halo growth."""
+    return value_and_grad(log_conc_mse_loss, argnums=0)(u_params, loss_data)
+
+
+def get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min=T_FIT_MIN):
+    logt_target, log_conc_target, msk = get_target_data(
+        t_sim,
+        conc_sim,
+        log_mah_sim,
+        lgm_min,
+        t_fit_min,
+    )
+    p_all = list(DEFAULT_CONC_PARAMS.values())
+    u_p_all = get_unbounded_params(p_all)
+    u_p0 = np.array((u_p_all[0], *u_p_all[2:]))
+
+    loss_data = (logt_target, log_conc_target, msk)
+    return u_p0, loss_data
+
+
+@jjit
+def _mse(pred, target):
+    """Mean square error used to define loss functions."""
+    diff = pred - target
+    return jnp.mean(diff * diff)
+
+
+def get_target_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min):
+    """"""
+    msk = log_mah_sim >= lgm_min
+    msk &= t_sim >= t_fit_min
+    msk &= conc_sim > 1
+
+    logt_target = np.log10(t_sim)[msk]
+    log_conc_target = np.log10(conc_sim[msk])
+    return logt_target, log_conc_target, msk
+
+
+@jjit
+def get_p_all_from_p_varied(p_varied):
+    p_all = jnp.array((p_varied[0], FIXED_K, *p_varied[1:])).astype("f4")
+    return p_all
+
+
+@jjit
+def get_p_varied_from_p_all(p_all):
+    p_varied = jnp.array((p_all[0], *p_all[2:])).astype("f4")
+    return p_varied
+
+
+def get_outline(halo_id, p_best, loss, method):
+    """Return the string storing fitting results that will be written to disk"""
+    _d = np.array(p_best).astype("f4")
+    data_out = (halo_id, method, *_d, float(loss))
+    outprefix = str(halo_id) + " " + str(method) + " "
+    outdata = " ".join(["{:.5e}".format(x) for x in data_out[2:]])
+    return outprefix + outdata + "\n"
+
+
+def get_outline_bad_fit(halo_id, p_best, loss, method):
+    conc_lgtc, conc_k, conc_beta_early, conc_beta_late = -1.0, -1.0, -1.0, -1.0
+    _d = np.array((conc_lgtc, conc_k, conc_beta_early, conc_beta_late)).astype("f4")
+    loss_best = -1.0
+    method = -1
+    data_out = (halo_id, method, *_d, float(loss_best))
+    outprefix = str(halo_id) + " " + str(method) + " "
+    outdata = " ".join(["{:.5e}".format(x) for x in data_out[2:]])
+    return outprefix + outdata + "\n"
+
+
+def get_header():
+    m = "# halo_id method conc_lgtc conc_k conc_beta_early conc_beta_late conc_loss\n"
+    return m
+
+
+def jax_adam_wrapper(
+    loss_and_grad_func,
+    params_init,
+    loss_data,
+    n_step,
+    step_size=0.2,
+    tol=-float("inf"),
+):
+    loss_arr = np.zeros(n_step).astype("f4") - 1.0
+    opt_init, opt_update, get_params = jax_opt.adam(step_size)
+    opt_state = opt_init(params_init)
+
+    best_loss = float("inf")
+    for istep in range(n_step):
+        p = jnp.array(get_params(opt_state))
+        loss, grads = loss_and_grad_func(p, loss_data)
+
+        nanmsk = ~np.isfinite(loss)
+        nanmsk &= ~np.all(np.isfinite(grads))
+        if nanmsk:
+            best_fit_params = np.nan
+            best_loss = np.nan
+            break
+
+        loss_arr[istep] = loss
+        if loss < best_loss:
+            best_fit_params = p
+            best_loss = loss
+        if loss < tol:
+            loss_arr[istep:] = best_loss
+            break
+        opt_state = opt_update(istep, grads, opt_state)
+
+    return best_fit_params, best_loss, loss_arr

--- a/diffprof/nfw_evolution.py
+++ b/diffprof/nfw_evolution.py
@@ -15,7 +15,7 @@ CONC_PARAM_BOUNDS = OrderedDict(
     conc_lgtc=(0.0, 1.5),
     conc_k=(0.25, 15.0),
     conc_beta_early=(10 ** LGC_LOG10_CLIP, 0.75),
-    conc_beta_late=(10 ** LGC_LOG10_CLIP, 2.0),
+    conc_beta_late=(10 ** LGC_LOG10_CLIP, 2.5),
 )
 
 

--- a/diffprof/tests/test_nfw_fitter.py
+++ b/diffprof/tests/test_nfw_fitter.py
@@ -3,6 +3,9 @@
 import numpy as np
 from ..nfw_evolution import lgc_vs_lgt, get_bounded_params
 from ..fit_nfw_helpers import fit_lgconc, get_loss_data
+from ..fit_nfw_helpers_fixed_k import fit_lgconc as fit_lgconc_fixed_k
+from ..fit_nfw_helpers_fixed_k import get_loss_data as get_loss_data_fixed_k
+from ..fit_nfw_helpers_fixed_k import FIXED_K
 
 SEED = 32
 
@@ -22,6 +25,32 @@ def test_conc_fitter():
     lgm_min = 0
     u_p0, _loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min)
     res = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min)
+    p_best, loss, method, loss_data = res
+    lgc_best = lgc_vs_lgt(lgt_sim, *p_best)
+    assert np.allclose(lgc_sim, lgc_best, atol=0.01)
+    assert np.allclose(p_best, p_target, atol=0.01)
+
+    # Enforce that the returned loss_data contains the expected information
+    for a, b in zip(_loss_data, loss_data):
+        assert np.allclose(a, b)
+
+
+def test_conc_fitter_fixed_k():
+    """Pick a random point in parameter space and demonstrate that the fitter
+    recovers the correct result.
+    """
+    t_sim = np.linspace(0.1, 14, 100)
+    lgt_sim = np.log10(t_sim)
+    rng = np.random.RandomState(SEED)
+    up_target = rng.normal(loc=0, size=4, scale=1)
+    p_target = np.array(get_bounded_params(up_target))
+    p_target[1] = FIXED_K
+    lgc_sim = lgc_vs_lgt(lgt_sim, *p_target)
+    conc_sim = 10 ** lgc_sim
+    log_mah_sim = np.zeros_like(conc_sim) + 100
+    lgm_min = 0
+    u_p0, _loss_data = get_loss_data_fixed_k(t_sim, conc_sim, log_mah_sim, lgm_min)
+    res = fit_lgconc_fixed_k(t_sim, conc_sim, log_mah_sim, lgm_min)
     p_best, loss, method, loss_data = res
     lgc_best = lgc_vs_lgt(lgt_sim, *p_best)
     assert np.allclose(lgc_sim, lgc_best, atol=0.01)


### PR DESCRIPTION
This PR brings in a new module, fit_nfw_helpers_fixed_k.py, that implements a 3-parameter NFW evolution model where the k parameter is held fixed to 4.0.

Note also that the upper bound on the beta_late parameter has been changed from 2.0 to 2.5, so in order to make a truly fair comparison between fits with and without k held fixed, the original fits ran by @dash-vich would need to be rerun. However, I think the following plot is reasonably convincing that, at least for the time being, we can safely proceed to use the fixed-k version of the fitter. 

![conc_fit_residuals_fixed_k](https://user-images.githubusercontent.com/6951595/125851938-5127dfa8-0bbb-496f-9ff8-3c95108c4c07.png)

Best-fitting parameters for the BPL simulation can be found at [the usual project URL](https://portal.nersc.gov/project/hacc/aphearin/diffprof_data/). The MDPL2 fits will need to be rerun based on this new fixed-k module before revisiting the population-level model.
