### PR TITLE
Added modules storing models of target data

### DIFF
--- a/diffprof/diffconc_std_lgconc_target_data_model.py
+++ b/diffprof/diffconc_std_lgconc_target_data_model.py
@@ -1,0 +1,67 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from collections import OrderedDict
+
+
+PARAMS = OrderedDict(
+    std_lgc_x0=11.960,
+    std_lgc_lgk=-0.572,
+    std_lgc_ylo_x0=13.690,
+    std_lgc_ylo_lgk=0.246,
+    std_lgc_ylo_ylo=0.117,
+    std_lgc_ylo_yhi=0.048,
+    std_lgc_yhi_x0=13.254,
+    std_lgc_yhi_lgk=-0.286,
+    std_lgc_yhi_ylo=0.361,
+    std_lgc_yhi_yhi=0.041,
+)
+
+
+@jjit
+def approx_std_lgconc_vs_lgm(
+    time,
+    lgmhalo,
+    std_lgc_x0,
+    std_lgc_lgk,
+    std_lgc_ylo_x0,
+    std_lgc_ylo_lgk,
+    std_lgc_ylo_ylo,
+    std_lgc_ylo_yhi,
+    std_lgc_yhi_x0,
+    std_lgc_yhi_lgk,
+    std_lgc_yhi_ylo,
+    std_lgc_yhi_yhi,
+):
+    ylo = get_std_model_ylo(
+        lgmhalo, std_lgc_ylo_x0, std_lgc_ylo_lgk, std_lgc_ylo_ylo, std_lgc_ylo_yhi
+    )
+    yhi = get_std_model_yhi(
+        lgmhalo, std_lgc_yhi_x0, std_lgc_yhi_lgk, std_lgc_yhi_ylo, std_lgc_yhi_yhi
+    )
+    return _sigmoid(time, std_lgc_x0, 10 ** std_lgc_lgk, ylo, yhi)
+
+
+@jjit
+def get_std_model_ylo(
+    lgmhalo, std_lgc_ylo_x0, std_lgc_ylo_lgk, std_lgc_ylo_ylo, std_lgc_ylo_yhi
+):
+    return _sigmoid(
+        lgmhalo, std_lgc_ylo_x0, 10 ** std_lgc_ylo_lgk, std_lgc_ylo_ylo, std_lgc_ylo_yhi
+    )
+
+
+@jjit
+def get_std_model_yhi(
+    lgmhalo, std_lgc_yhi_x0, std_lgc_yhi_lgk, std_lgc_yhi_ylo, std_lgc_yhi_yhi
+):
+    return _sigmoid(
+        lgmhalo, std_lgc_yhi_x0, 10 ** std_lgc_yhi_lgk, std_lgc_yhi_ylo, std_lgc_yhi_yhi
+    )
+
+
+@jjit
+def _sigmoid(x, tp, k, ylo, yhi):
+    height_diff = yhi - ylo
+    return ylo + height_diff / (1 + jnp.exp(-k * (x - tp)))

--- a/diffprof/diffconc_target_data_model.py
+++ b/diffprof/diffconc_target_data_model.py
@@ -1,0 +1,92 @@
+"""
+"""
+from collections import OrderedDict
+from jax import numpy as jnp
+from jax import jit as jjit
+
+
+PARAMS = OrderedDict(
+    x0_data=-4.954,
+    lgk_data=-1.003,
+    x0_ylo=0.723,
+    lgk_ylo=0.455,
+    ylo_ylo_w0=-6.865,
+    ylo_ylo_w1=0.413,
+    ylo_yhi_v0=-1.478,
+    ylo_yhi_v1=0.163,
+    yhi_c0_b0=4.317,
+    yhi_c0_b1=-0.221,
+    yhi_c1_a0=-1.749,
+    yhi_c1_a1=0.086,
+)
+
+
+@jjit
+def approximate_lgconc_vs_lgm_p50(
+    t,
+    lgmh,
+    p50,
+    x0_data,
+    lgk_data,
+    x0_ylo,
+    lgk_ylo,
+    ylo_ylo_w0,
+    ylo_ylo_w1,
+    ylo_yhi_v0,
+    ylo_yhi_v1,
+    yhi_c0_b0,
+    yhi_c0_b1,
+    yhi_c1_a0,
+    yhi_c1_a1,
+):
+    ylo_ylo, ylo_yhi = get_ylo_sigmoid_params(
+        lgmh, ylo_ylo_w0, ylo_ylo_w1, ylo_yhi_v0, ylo_yhi_v1
+    )
+    yhi_c0, yhi_c1 = get_yhi_coeffs(lgmh, yhi_c0_b0, yhi_c0_b1, yhi_c1_a0, yhi_c1_a1)
+    ylo = _sigmoid(p50, x0_ylo, 10 ** lgk_ylo, ylo_ylo, ylo_yhi)
+    yhi = yhi_c0 + yhi_c1 * p50
+    return _sigmoid(t, x0_data, 10 ** lgk_data, ylo, yhi)
+
+
+@jjit
+def _sigmoid(x, tp, k, ylo, yhi):
+    height_diff = yhi - ylo
+    return ylo + height_diff / (1 + jnp.exp(-k * (x - tp)))
+
+
+@jjit
+def get_ylo_sigmoid_params(lgmhalo, ylo_ylo_w0, ylo_ylo_w1, ylo_yhi_v0, ylo_yhi_v1):
+    ylo_ylo = get_ylo_ylo(lgmhalo, ylo_ylo_w0, ylo_ylo_w1)
+    ylo_yhi = get_ylo_yhi(lgmhalo, ylo_yhi_v0, ylo_yhi_v1)
+    return ylo_ylo, ylo_yhi
+
+
+@jjit
+def get_yhi_coeffs(lgmhalo, yhi_c0_b0, yhi_c0_b1, yhi_c1_a0, yhi_c1_a1):
+    yhi_c0 = get_yhi_c0(lgmhalo, yhi_c0_b0, yhi_c0_b1)
+    yhi_c1 = get_yhi_c1(lgmhalo, yhi_c1_a0, yhi_c1_a1)
+    return yhi_c0, yhi_c1
+
+
+@jjit
+def get_ylo_ylo(lgmhalo, ylo_ylo_w0, ylo_ylo_w1):
+    ylo_ylo = ylo_ylo_w0 + ylo_ylo_w1 * lgmhalo
+    return ylo_ylo
+
+
+@jjit
+def get_ylo_yhi(lgmhalo, ylo_yhi_v0, ylo_yhi_v1):
+    ylo_yhi = ylo_yhi_v0 + ylo_yhi_v1 * lgmhalo
+    return ylo_yhi
+
+
+@jjit
+def get_yhi_c0(lgmhalo, yhi_c0_b0, yhi_c0_b1):
+    yhi_c0 = yhi_c0_b0 + yhi_c0_b1 * lgmhalo
+    return yhi_c0
+
+
+@jjit
+def get_yhi_c1(lgmhalo, yhi_c1_a0, yhi_c1_a1):
+    yhi_c1 = yhi_c1_a0 + yhi_c1_a1 * lgmhalo
+    return yhi_c1

--- a/diffprof/fit_target_data_model.py
+++ b/diffprof/fit_target_data_model.py
@@ -1,0 +1,39 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import vmap
+from diffconc_target_data_model import approximate_lgconc_vs_lgm_p50
+
+
+@jjit
+def predict_lgconc_vs_lgm_p50(varied_params, tarr, lgmhalo_arr, p50_arr):
+    params = get_params_from_varied_params(varied_params)
+    lgconc = approximate_lgconc_vs_lgm_p50(tarr, lgmhalo_arr, p50_arr, *params)
+    return lgconc
+
+
+@jjit
+def get_params_from_varied_params(varied_params):
+    return varied_params
+
+
+predict_targets = jjit(
+    vmap(
+        vmap(predict_lgconc_vs_lgm_p50, in_axes=(None, None, None, 0)),
+        in_axes=(None, None, 0, None),
+    )
+)
+
+
+@jjit
+def _mse(pred, target):
+    diff = pred - target
+    return jnp.mean(diff * diff)
+
+
+@jjit
+def _loss(params, loss_data):
+    tarr, lgmhalo_arr, p50_arr, lgc_targets = loss_data
+    lgc_preds = predict_targets(params, tarr, lgmhalo_arr, p50_arr)
+    return _mse(lgc_preds, lgc_targets)

--- a/diffprof/fit_target_std_data_model.py
+++ b/diffprof/fit_target_std_data_model.py
@@ -1,0 +1,36 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import vmap
+from diffconc_std_lgconc_target_data_model import approx_std_lgconc_vs_lgm
+
+
+@jjit
+def diffconc_std_lgconc_target_data_model(varied_params, tarr, lgmhalo_arr):
+    params = get_params_from_varied_params(varied_params)
+    std_lgconc = approx_std_lgconc_vs_lgm(tarr, lgmhalo_arr, *params)
+    return std_lgconc
+
+
+@jjit
+def get_params_from_varied_params(varied_params):
+    return varied_params
+
+
+predict_std_targets = jjit(
+    vmap(diffconc_std_lgconc_target_data_model, in_axes=(None, None, 0))
+)
+
+
+@jjit
+def _mse(pred, target):
+    diff = pred - target
+    return jnp.mean(diff * diff)
+
+
+@jjit
+def _std_model_loss(params, loss_data):
+    tarr, lgmhalo_arr, std_lgc_targets = loss_data
+    std_lgc_preds = predict_std_targets(params, tarr, lgmhalo_arr)
+    return _mse(std_lgc_preds, std_lgc_targets)


### PR DESCRIPTION
The code in this PR addresses the following nuisance. When we measure the average concentration histories of simulated halos, there is unavoidably some noise due to finite sample sizes. This can lead to features in the measurements that are probably unphysical, such as non-monotonic behavior, brief blips in the mass- and/or t-form-dependence, etc. If we were to naively train our population model using such target data, we might unwittingly inherit these unphysical features. So this PR brings in code that can serve as an approximation to the target data we will use to fit our population model. So these modules can be thought of as simply direct fitting functions to use instead of the measurements. I'll refer to the collection of these fitting functions as "the target data model". 

This plot shows the residuals of the fit to the average halo concentration as a function of cosmic time, halo mass, and halo formation time. So the upshot of this plot is that the target data model gives an accurate approximation to mean relations. 

![mean_conc_residuals_t50_dependence_4_mass_panels](https://user-images.githubusercontent.com/6951595/130478217-0994fa4b-a651-4fde-bf0b-a4438d8ccc46.png)

This plot shows the residuals of the fit to the variance of the halo concentration as a function of cosmic time, halo mass, and halo formation time. So the upshot of this plot is that the target data model gives an accurate approximation to the scatter.
![std_conc_residuals_mass_dependence](https://user-images.githubusercontent.com/6951595/130478351-84834019-0499-4ae0-a0ef-7f1baad6c1c0.png)




