### PR TITLE
Linear time

### DIFF
--- a/diffprof/fit_nfw_helpers_lintime.py
+++ b/diffprof/fit_nfw_helpers_lintime.py
@@ -134,7 +134,7 @@ def get_outline_bad_fit(halo_id, p_best, loss, method):
 
 
 def get_header():
-    m = "# halo_id method conc_lgtc lgc_min lgc_late conc_loss\n"
+    m = "# halo_id method conc_tc lgc_min lgc_late conc_loss\n"
     return m
 
 

--- a/diffprof/fit_nfw_helpers_lintime.py
+++ b/diffprof/fit_nfw_helpers_lintime.py
@@ -1,0 +1,163 @@
+"""Helper functions for fitting NFW concentration histories of individual halos."""
+import warnings
+import numpy as np
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import value_and_grad, grad
+from jax import vmap as jvmap
+from jax.experimental import optimizers as jax_opt
+from scipy.optimize import curve_fit
+from .nfw_evolution_lintime import u_lgc_vs_t, DEFAULT_CONC_PARAMS
+from .nfw_evolution_lintime import get_unbounded_params, get_bounded_params
+
+T_FIT_MIN = 2.0
+
+
+_a = (0, None, None, None)
+_jac_func = jjit(jvmap(grad(u_lgc_vs_t, argnums=(1, 2, 3)), in_axes=_a))
+
+
+def fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, n_step=300, t_fit_min=T_FIT_MIN):
+    u_p0, loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min)
+    t, lgc, msk = loss_data
+
+    if len(lgc) < 10:
+        method = -1
+        p_best = np.nan
+        loss = np.nan
+        return p_best, loss, method, loss_data
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        try:
+            u_p = curve_fit(u_lgc_vs_t, t, lgc, p0=u_p0, jac=jac_lgc)[0]
+            method = 0
+            p_best = get_bounded_params(u_p)
+            loss = log_conc_mse_loss(u_p, loss_data)
+        except RuntimeError:
+            res = jax_adam_wrapper(log_conc_mse_loss_and_grads, u_p0, loss_data, n_step)
+            u_p = res[0]
+            if ~np.all(np.isfinite(u_p)):
+                method = -1
+                p_best = np.nan
+                loss = np.nan
+            else:
+                method = 1
+                p_best = get_bounded_params(u_p)
+                loss = log_conc_mse_loss(u_p, loss_data)
+    return p_best, loss, method, loss_data
+
+
+def jac_lgc(t, u_conc_lgtc, u_lgc_min, u_lgc_late):
+    grads = _jac_func(t, u_conc_lgtc, u_lgc_min, u_lgc_late)
+    return np.array(grads).T
+
+
+@jjit
+def log_conc_mse_loss(u_params, loss_data):
+    """MSE loss function for fitting individual halo growth."""
+    lgt_target, log_conc_target, msk = loss_data
+    u_conc_lgtc, u_lgc_min, u_lgc_late = u_params
+    log_conc_pred = u_lgc_vs_t(lgt_target, u_conc_lgtc, u_lgc_min, u_lgc_late)
+    log_conc_loss = _mse(log_conc_pred, log_conc_target)
+    return log_conc_loss
+
+
+@jjit
+def log_conc_mse_loss_and_grads(u_params, loss_data):
+    """MSE loss and grad function for fitting individual halo growth."""
+    return value_and_grad(log_conc_mse_loss, argnums=0)(u_params, loss_data)
+
+
+def get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min=T_FIT_MIN):
+    t_target, log_conc_target, msk = get_target_data(
+        t_sim,
+        conc_sim,
+        log_mah_sim,
+        lgm_min,
+        t_fit_min,
+    )
+    u_p0 = get_unbounded_params(list(DEFAULT_CONC_PARAMS.values()))
+
+    loss_data = (t_target, log_conc_target, msk)
+    return u_p0, loss_data
+
+
+def get_target_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min):
+    """"""
+    msk = log_mah_sim >= lgm_min
+    msk &= t_sim >= t_fit_min
+    msk &= conc_sim > 1
+
+    t_target = t_sim[msk]
+    log_conc_target = np.log10(conc_sim[msk])
+    return t_target, log_conc_target, msk
+
+
+@jjit
+def _mse(pred, target):
+    """Mean square error used to define loss functions."""
+    diff = pred - target
+    return jnp.mean(diff * diff)
+
+
+def get_outline(halo_id, p_best, loss, method):
+    """Return the string storing fitting results that will be written to disk"""
+    _d = np.array(p_best).astype("f4")
+    data_out = (halo_id, method, *_d, float(loss))
+    outprefix = str(halo_id) + " " + str(method) + " "
+    outdata = " ".join(["{:.5e}".format(x) for x in data_out[2:]])
+    return outprefix + outdata + "\n"
+
+
+def get_outline_bad_fit(halo_id, p_best, loss, method):
+    conc_lgtc, lgc_min, lgc_late = -1.0, -1.0, -1.0
+    _d = np.array((conc_lgtc, lgc_min, lgc_late)).astype("f4")
+    loss_best = -1.0
+    method = -1
+    data_out = (halo_id, method, *_d, float(loss_best))
+    outprefix = str(halo_id) + " " + str(method) + " "
+    outdata = " ".join(["{:.5e}".format(x) for x in data_out[2:]])
+    return outprefix + outdata + "\n"
+
+
+def get_header():
+    m = "# halo_id method conc_lgtc lgc_min lgc_late conc_loss\n"
+    return m
+
+
+def jax_adam_wrapper(
+    loss_and_grad_func,
+    params_init,
+    loss_data,
+    n_step,
+    step_size=0.2,
+    tol=-float("inf"),
+):
+    loss_arr = np.zeros(n_step).astype("f4") - 1.0
+    opt_init, opt_update, get_params = jax_opt.adam(step_size)
+    opt_state = opt_init(params_init)
+
+    best_loss = float("inf")
+    for istep in range(n_step):
+        p = jnp.array(get_params(opt_state))
+        loss, grads = loss_and_grad_func(p, loss_data)
+
+        nanmsk = ~np.isfinite(loss)
+        nanmsk &= ~np.all(np.isfinite(grads))
+        if nanmsk:
+            best_fit_params = np.nan
+            best_loss = np.nan
+            break
+
+        loss_arr[istep] = loss
+        if loss < best_loss:
+            best_fit_params = p
+            best_loss = loss
+        if loss < tol:
+            loss_arr[istep:] = best_loss
+            break
+        opt_state = opt_update(istep, grads, opt_state)
+
+    return best_fit_params, best_loss, loss_arr

--- a/diffprof/fit_nfw_helpers_lintime.py
+++ b/diffprof/fit_nfw_helpers_lintime.py
@@ -17,8 +17,12 @@ _a = (0, None, None, None)
 _jac_func = jjit(jvmap(grad(u_lgc_vs_t, argnums=(1, 2, 3)), in_axes=_a))
 
 
-def fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, n_step=300, t_fit_min=T_FIT_MIN):
-    u_p0, loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min)
+def fit_lgconc(
+    t_sim, conc_sim, log_mah_sim, lgm_min, n_step=300, t_fit_min=T_FIT_MIN, p0=None
+):
+    u_p0, loss_data = get_loss_data(
+        t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min, p0=p0
+    )
     t, lgc, msk = loss_data
 
     if len(lgc) < 10:
@@ -70,7 +74,7 @@ def log_conc_mse_loss_and_grads(u_params, loss_data):
     return value_and_grad(log_conc_mse_loss, argnums=0)(u_params, loss_data)
 
 
-def get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min=T_FIT_MIN):
+def get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min, p0):
     t_target, log_conc_target, msk = get_target_data(
         t_sim,
         conc_sim,
@@ -78,7 +82,10 @@ def get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min, t_fit_min=T_FIT_MIN):
         lgm_min,
         t_fit_min,
     )
-    u_p0 = get_unbounded_params(list(DEFAULT_CONC_PARAMS.values()))
+    if p0 is None:
+        u_p0 = get_unbounded_params(list(DEFAULT_CONC_PARAMS.values()))
+    else:
+        u_p0 = get_unbounded_params(p0)
 
     loss_data = (t_target, log_conc_target, msk)
     return u_p0, loss_data

--- a/diffprof/nfw_evolution_lintime.py
+++ b/diffprof/nfw_evolution_lintime.py
@@ -4,11 +4,13 @@ from collections import OrderedDict
 from jax import jit as jjit
 from jax import numpy as jnp
 
+_X0, _K = 0.0, 0.1
+
 CONC_K = 0.25
 
-DEFAULT_CONC_PARAMS = OrderedDict(conc_lgtc=0.7, lgc_min=0.35, lgc_late=1.2)
+DEFAULT_CONC_PARAMS = OrderedDict(lgtc=0.7, lgc_min=0.35, lgc_late=1.2)
 CONC_PARAM_BOUNDS = OrderedDict(
-    conc_lgtc=(0.0, 1.5),
+    lgtc=(0.0, 1.5),
     lgc_min=(jnp.log10(2.0), jnp.log10(5.5)),
     lgc_late=(jnp.log10(2.0), jnp.log10(300.0)),
 )
@@ -43,6 +45,87 @@ def lgc_vs_t(t, lgtc, lgc_min, lgc_late):
 
 
 @jjit
+def u_lgc_vs_t(t, u_conc_lgtc, u_lgc_min, u_lgc_late):
+    u_params = u_conc_lgtc, u_lgc_min, u_lgc_late
+    params = get_bounded_params(u_params)
+    return lgc_vs_t(t, *params)
+
+
+@jjit
+def get_bounded_params(u_params):
+    u_conc_lgtc, u_lgc_min, u_lgc_late = u_params
+    conc_lgtc = _get_lgtc(u_conc_lgtc)
+    lgc_min = _get_lgc_min(u_lgc_min)
+    lgc_late = _get_lgc_late(u_lgc_late, lgc_min)
+    return jnp.array((conc_lgtc, lgc_min, lgc_late))
+
+
+@jjit
+def get_unbounded_params(params):
+    """Retrieve unbounded version of model parameters used to fit concentration history.
+
+    Parameters
+    ----------
+    params : sequence
+        Values of the model parameters. Values should respect the parameter bounds.
+
+    Returns
+    -------
+    u_params : sequence
+        Values of the unbounded version of the model parameters.
+
+    Notes
+    -----
+    lgtc, k, and lgc_early have simple rectangular bounds set by CONC_PARAM_BOUNDS.
+    The lower bound on lgc_late is lgc_early.
+
+    """
+    conc_lgtc, lgc_min, lgc_late = params
+    u_conc_lgtc = _get_u_lgtc(conc_lgtc)
+    u_lgc_min = _get_u_lgc_min(lgc_min)
+    u_lgc_late = _get_u_lgc_late(lgc_late, lgc_min)
+    return jnp.array((u_conc_lgtc, u_lgc_min, u_lgc_late))
+
+
+@jjit
+def _get_lgc_late(u_lgc_late, lgc_min):
+    ylo, yhi = lgc_min, CONC_PARAM_BOUNDS["lgc_late"][1]
+    return _sigmoid(u_lgc_late, _X0, _K, ylo, yhi)
+
+
+@jjit
+def _get_u_lgc_late(lgc_late, lgc_min):
+    ylo, yhi = lgc_min, CONC_PARAM_BOUNDS["lgc_late"][1]
+    return _inverse_sigmoid(lgc_late, _X0, _K, ylo, yhi)
+
+
+@jjit
+def _get_lgtc(u_conc_lgtc):
+    return _sigmoid(u_conc_lgtc, _X0, _K, *CONC_PARAM_BOUNDS["lgtc"])
+
+
+@jjit
+def _get_u_lgtc(conc_lgtc):
+    return _inverse_sigmoid(conc_lgtc, _X0, _K, *CONC_PARAM_BOUNDS["lgtc"])
+
+
+@jjit
+def _get_lgc_min(u_lgc_min):
+    return _sigmoid(u_lgc_min, _X0, _K, *CONC_PARAM_BOUNDS["lgc_min"])
+
+
+@jjit
+def _get_u_lgc_min(lgc_min):
+    return _inverse_sigmoid(lgc_min, _X0, _K, *CONC_PARAM_BOUNDS["lgc_min"])
+
+
+@jjit
 def _sigmoid(x, x0, k, ymin, ymax):
     height_diff = ymax - ymin
     return ymin + height_diff / (1.0 + jnp.exp(-k * (x - x0)))
+
+
+@jjit
+def _inverse_sigmoid(y, x0, k, ymin, ymax):
+    lnarg = (ymax - ymin) / (y - ymin) - 1
+    return x0 - jnp.log(lnarg) / k

--- a/diffprof/nfw_evolution_lintime.py
+++ b/diffprof/nfw_evolution_lintime.py
@@ -10,7 +10,7 @@ CONC_K = 0.25
 
 DEFAULT_CONC_PARAMS = OrderedDict(lgtc=0.7, lgc_min=0.35, lgc_late=1.2)
 CONC_PARAM_BOUNDS = OrderedDict(
-    lgtc=(0.0, 1.5),
+    lgtc=(-1.0, 1.5),
     lgc_min=(jnp.log10(2.0), jnp.log10(5.5)),
     lgc_late=(jnp.log10(2.0), jnp.log10(300.0)),
 )

--- a/diffprof/nfw_evolution_lintime.py
+++ b/diffprof/nfw_evolution_lintime.py
@@ -1,0 +1,48 @@
+"""Module stores the lgc_vs_lgt function providing a model for NFW conc vs. time
+"""
+from collections import OrderedDict
+from jax import jit as jjit
+from jax import numpy as jnp
+
+CONC_K = 0.25
+
+DEFAULT_CONC_PARAMS = OrderedDict(conc_lgtc=0.7, lgc_min=0.35, lgc_late=1.2)
+CONC_PARAM_BOUNDS = OrderedDict(
+    conc_lgtc=(0.0, 1.5),
+    lgc_min=(jnp.log10(2.0), jnp.log10(5.5)),
+    lgc_late=(jnp.log10(2.0), jnp.log10(300.0)),
+)
+
+
+@jjit
+def lgc_vs_t(t, lgtc, lgc_min, lgc_late):
+    """Model for evolution of NFW concentration vs time for individual halos
+
+    Parameters
+    ----------
+    t : ndarray of shape (n, )
+        cosmic time in Gyr
+
+    lgtc : float
+        Base-10 log of cosmic time in Gyr when halo concentration begins to rise
+
+    lgc_min : float
+        Power-law index of early-time concentration growth
+
+    lgc_late : float
+        Power-law index of late-time concentration growth
+
+    Returns
+    -------
+    lgc : ndarray of shape (n, )
+        Base-10 log of NFW concentration
+
+    """
+    lgc = _sigmoid(t, 10 ** lgtc, CONC_K, lgc_min, lgc_late)
+    return lgc
+
+
+@jjit
+def _sigmoid(x, x0, k, ymin, ymax):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1.0 + jnp.exp(-k * (x - x0)))

--- a/diffprof/tests/test_nfw_evolution_lintime.py
+++ b/diffprof/tests/test_nfw_evolution_lintime.py
@@ -1,0 +1,52 @@
+"""
+"""
+import os
+import numpy as np
+from ..nfw_evolution_lintime import lgc_vs_t, u_lgc_vs_t
+from ..nfw_evolution_lintime import CONC_PARAM_BOUNDS, DEFAULT_CONC_PARAMS
+from ..nfw_evolution_lintime import get_bounded_params, get_unbounded_params
+
+_THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
+DDRN = os.path.join(_THIS_DRNAME, "testing_data")
+
+
+def test_bounded_params():
+    p = np.array(list(DEFAULT_CONC_PARAMS.values()))
+    u_p = get_unbounded_params(p)
+    p2 = get_bounded_params(u_p)
+    assert np.allclose(p, p2, atol=0.01)
+
+
+def test_default_params_are_within_bounds():
+    for key, bounds in CONC_PARAM_BOUNDS.items():
+        assert bounds[0] < DEFAULT_CONC_PARAMS[key] < bounds[1]
+
+
+def test_unbounded_params():
+    n_test = 10
+    for itest in range(n_test):
+        rng = np.random.RandomState(itest)
+        up = rng.uniform(-5, 5, 3)
+        p = get_bounded_params(up)
+        up2 = get_unbounded_params(p)
+        assert np.allclose(up, up2, atol=0.01)
+
+
+def test_consistency_u_lgc_vs_t():
+    tarr = np.linspace(1, 13.8, 50)
+    n_test = 10
+    for itest in range(n_test):
+        rng = np.random.RandomState(itest)
+        up = rng.uniform(-5, 5, 3)
+        p = get_bounded_params(up)
+        lgc = lgc_vs_t(tarr, *p)
+        lgc2 = u_lgc_vs_t(tarr, *up)
+        assert np.allclose(lgc, lgc2, atol=0.01)
+
+
+def test_lgc_vs_t_behaves_reasonably_at_defaults():
+    tarr = np.linspace(0.1, 14, 50)
+    p = np.array(list(DEFAULT_CONC_PARAMS.values()))
+    lgc = lgc_vs_t(tarr, *p)
+    assert np.all(lgc >= CONC_PARAM_BOUNDS["lgc_min"][0])
+    assert np.all(lgc < CONC_PARAM_BOUNDS["lgc_late"][1])

--- a/diffprof/tests/test_nfw_fitter_lintime.py
+++ b/diffprof/tests/test_nfw_fitter_lintime.py
@@ -1,0 +1,31 @@
+"""
+"""
+import numpy as np
+from ..nfw_evolution_lintime import lgc_vs_t, get_bounded_params
+from ..fit_nfw_helpers_lintime import fit_lgconc, get_loss_data
+
+SEED = 32
+
+
+def test_conc_fitter():
+    """Pick a random point in parameter space and demonstrate that the fitter
+    recovers the correct result.
+    """
+    t_sim = np.linspace(0.1, 14, 100)
+    rng = np.random.RandomState(SEED)
+    up_target = rng.normal(loc=0, size=3, scale=1)
+    p_target = get_bounded_params(up_target)
+    lgc_sim = lgc_vs_t(t_sim, *p_target)
+    conc_sim = 10 ** lgc_sim
+    log_mah_sim = np.zeros_like(conc_sim) + 100
+    lgm_min = 0
+    u_p0, _loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min)
+    res = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min)
+    p_best, loss, method, loss_data = res
+    lgc_best = lgc_vs_t(t_sim, *p_best)
+    assert np.allclose(lgc_sim, lgc_best, atol=0.01)
+    assert np.allclose(p_best, p_target, atol=0.01)
+
+    # Enforce that the returned loss_data contains the expected information
+    for a, b in zip(_loss_data, loss_data):
+        assert np.allclose(a, b)

--- a/diffprof/tests/test_nfw_fitter_lintime.py
+++ b/diffprof/tests/test_nfw_fitter_lintime.py
@@ -52,9 +52,4 @@ def test_conc_fitter_initial_point():
     res2 = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, p0=P_INIT)
     p_best2, loss, method, loss_data = res2
 
-    up_ranstart = rng.normal(loc=up_target, scale=1)
-    res3 = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, p0=up_ranstart)
-    p_best3, loss, method, loss_data = res3
-
     assert np.allclose(p_best, p_best2)
-    assert not np.allclose(p_best, p_best3)

--- a/diffprof/tests/test_nfw_fitter_lintime.py
+++ b/diffprof/tests/test_nfw_fitter_lintime.py
@@ -32,3 +32,29 @@ def test_conc_fitter():
     # Enforce that the returned loss_data contains the expected information
     for a, b in zip(_loss_data, loss_data):
         assert np.allclose(a, b)
+
+
+def test_conc_fitter_initial_point():
+    P_INIT = np.array(list(DEFAULT_CONC_PARAMS.values()))
+    t_sim = np.linspace(0.1, 14, 100)
+
+    rng = np.random.RandomState(SEED)
+    up_target = rng.normal(loc=0, size=3, scale=1)
+    p_target = get_bounded_params(up_target)
+    lgc_sim = lgc_vs_t(t_sim, *p_target)
+    conc_sim = 10 ** lgc_sim
+    log_mah_sim = np.zeros_like(conc_sim) + 100
+    lgm_min = 0
+
+    res = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min)
+    p_best, loss, method, loss_data = res
+
+    res2 = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, p0=P_INIT)
+    p_best2, loss, method, loss_data = res2
+
+    up_ranstart = rng.normal(loc=up_target, scale=1)
+    res3 = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min, p0=up_ranstart)
+    p_best3, loss, method, loss_data = res3
+
+    assert np.allclose(p_best, p_best2)
+    assert not np.allclose(p_best, p_best3)

--- a/diffprof/tests/test_nfw_fitter_lintime.py
+++ b/diffprof/tests/test_nfw_fitter_lintime.py
@@ -1,8 +1,8 @@
 """
 """
 import numpy as np
-from ..nfw_evolution_lintime import lgc_vs_t, get_bounded_params
-from ..fit_nfw_helpers_lintime import fit_lgconc, get_loss_data
+from ..nfw_evolution_lintime import lgc_vs_t, get_bounded_params, DEFAULT_CONC_PARAMS
+from ..fit_nfw_helpers_lintime import fit_lgconc, get_loss_data, T_FIT_MIN
 
 SEED = 32
 
@@ -11,6 +11,7 @@ def test_conc_fitter():
     """Pick a random point in parameter space and demonstrate that the fitter
     recovers the correct result.
     """
+    P_INIT = np.array(list(DEFAULT_CONC_PARAMS.values()))
     t_sim = np.linspace(0.1, 14, 100)
     rng = np.random.RandomState(SEED)
     up_target = rng.normal(loc=0, size=3, scale=1)
@@ -19,7 +20,9 @@ def test_conc_fitter():
     conc_sim = 10 ** lgc_sim
     log_mah_sim = np.zeros_like(conc_sim) + 100
     lgm_min = 0
-    u_p0, _loss_data = get_loss_data(t_sim, conc_sim, log_mah_sim, lgm_min)
+    u_p0, _loss_data = get_loss_data(
+        t_sim, conc_sim, log_mah_sim, lgm_min, T_FIT_MIN, P_INIT
+    )
     res = fit_lgconc(t_sim, conc_sim, log_mah_sim, lgm_min)
     p_best, loss, method, loss_data = res
     lgc_best = lgc_vs_t(t_sim, *p_best)

--- a/notebooks/validate_new_fitter.ipynb
+++ b/notebooks/validate_new_fitter.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "measured-drinking",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "coated-original",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['halo_id', 'conc_beta_early', 'conc_beta_late', 'conc_k', 'conc_lgtc', 'u_conc_beta_early', 'u_conc_beta_late', 'u_conc_k', 'u_conc_lgtc', 'logmp', 'mah_early', 'mah_late', 'mah_logtc', 'mah_k', 'log_mah_fit', 'conch_fit', 'tform_50', 'p_tform_50', 'conch_sim']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from astropy.table import Table\n",
+    "from halotools.sim_manager import CachedHaloCatalog\n",
+    "from halotools.utils import crossmatch\n",
+    "from halotools.utils import sliding_conditional_percentile\n",
+    "from time import time\n",
+    "import matplotlib.cm as cm\n",
+    "\n",
+    "drn = \"/Users/aphearin/work/DATA/diffprof_data\"\n",
+    "t_bpl = np.load(\"/Users/aphearin/work/DATA/diffmah_data/PUBLISHED_DATA/bpl_cosmic_time.npy\")\n",
+    "bpl = Table.read(os.path.join(drn, \"BPL_halo_table.hdf5\"))\n",
+    "bpl_raw = np.load(os.path.join(drn, \"bpl_cens_trunks_conc.npy\"))\n",
+    "assert np.allclose(bpl['halo_id'], bpl_raw['halo_id'])\n",
+    "bpl['conch_sim'] = bpl_raw['conc']\n",
+    "del bpl_raw\n",
+    "print(bpl.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eleven-company",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lgm0 = 12\n",
+    "\n",
+    "mmsk = np.abs(bpl['logmp'] - lgm0) < 0.1\n",
+    "sample = bpl[mmsk]\n",
+    "\n",
+    "TARR = np.linspace(1, 13.8, 500)\n",
+    "LGTARR = np.log10(TARR)\n",
+    "LGM_MIN_BPL = 10.5\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "provincial-gilbert",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tc = nan\n",
+      "c_min = nan\n",
+      "c_late = nan\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAD9CAYAAABKgkezAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABNWklEQVR4nO3dd3xb9b3/8dfRtoYt7x2vOMvZi4Swk0ChjLJHKaOMDrgdv95C6QC6bgu03AJtbwtllNLbW8IqUFbYK3svJ04cO4nteMu2rK3z/f1xZMd2vEdkOd/n45FHYuno6Csrfvurz/kORQiBJEmSFJt00W6AJEmSNHwyxCVJkmKYDHFJkqQYJkNckiQphskQlyRJimEyxCVJkmKYYaADFEVxArdHvlwErBZCPN7jmLuAciAJoOf9kiRJ0tgYMMSBe4QQd3d8oSjKAUVROoNaUZQHgA1CiBc6vlYU5YqOryVJkqSxo/Q32SfSC39CCHFll9vuAr4mhCiKfN0shEjscv984AEhxMrezpmSkiLy8/NHp/WSJEkniU2bNjUIIVJ73j6YnvgKRVEKhRDlka9dQCF0BnZPLmBFXyfLz89n48aNg3haSZIkqYOiKJW93d5viAshXEBij5tXAu9G/p0ENPW4v+fXkiRJ0hgZ0uiUSHllBdBRI3cOcOxxqqurURSl88/9998/lCZIkiRJXQymnNLVE8CVQojNka9dREakdNHz626ysrKorq4e4tNKkiRJvRl0TzxyQfPPQoh3u9zcxPG9cSd0lmIkSZKkMTSoEFcU5Qpgc0eAK4qyAiDSI3f1ODyJYzVzSZIkaQwNGOKRwE4CNiqK4lQUpRDoOirl+UjId1gJ/Hl0mylJkiT1pt+aeOTi5OrIl12DuXMijxDia4qi3BUJ+0LggJzoI0mSdGIMZoihMtBJhBAPjlaDJEmS+lNVvotDHzzNkpsfRNHJ5Z/kd0CSpJhy+PNVLD38BA1HD0W7KeOCDHFJkmJLKABAW1NtlBsyPsgQlyQppoiwFuKe5qNRbsn4IENckqTYEglxf2t9lBsyPsgQlyQppiiREA+1yRAHGeKSJMWYjhBX2xui3JLxQYa4JEmxRQ0CoPPKBVNBhrgkSTFGFwlxo68xyi0ZH2SIS5IUUzrKKeaAK7oNGSdkiEuSFFM6euLWkCu6DRknZIhLkhRTdEILcYfaEuWWjA8yxCVJiik6VSunOEUrQlWj3JrokyEuSVJM0UfKKQZFpdUlL27KEJckKaboRajz361Ncuq9DHFJkmKKXgQJCS262mWIyxCXJCm2GNQgDYq2H7uvRU69lyEuSVJM0ROkxZACQKC1LsqtiT4Z4pIkxRSDCNFuTgUg7JY9cRnikiTFFIMIEjLF4xUmFI8cnSJDXJKkmGIkhNAZaVES0PvkIlgyxCVJiikGEUTozbj18ZgCzdFuTtTJEJckKaYYCSH0RjzGROKCrmg3J+pkiEuSFDOEqmIiBHoTAZMTe1iunyJDXJKkmBEOh9ApAvQmQpZkEuQiWDLEJUmKHcGAHwBFbwJrCjbFh8/bHuVWRZcMcUmSYkYgEuIYTCi2ZABaGk/uqfcyxCVJihlBvxfQeuLG+DQA2mSIS5IkxYZQMFJOMZixJGizNr0tJ/fUexnikiTFjHBniJuwJWYA4JchLkmSFBtCfh8AOoOJhGQtxEPuhmg2KepkiEuSFDM6yik6o4X4xFTCQkG0yxCXJEmKCeGQtr+mzmBCp9fTojjQeU/uRbBkiEuSFDM6auI6gxmANl0CRt/JvX6KDHFJkmJGOKDVxPVGEwDtBieWoAxxSZKkmNBRTtEbtZ64z5iINeSKYouiT4a4JEkxQ42UUzpCPGhJJP4kXz9FhrgkSTFDDQUBMJi0EFfjkkkQbajhcDSbFVUyxCVJihkipNXEDUYLAIo1Gb0iaG0+effalCEuSVLMEJGaeEdP3ODQpt6fzItgyRCXJClmqD1C3JygLYLlcdVGrU3RJkNckqSYIULahU1j5MJmXCTEva6Td/0UGeKSJMWOsNYTN5q1mrijY/2UtpO3Jm4Y6ABFUZzA7UCyEOLuHvfdDiwAVkVuuhJ4QAhRPsrtlCRJQnSEuEkL8Y5FsNSTeBGsfkNcUZQVgBMo6uewq9BCfjNwmwxwSZLGTDgyxNBgBMASZ6NdWMAjQ7xXQoh3ARRFWYQW5r0dkzj6zZIkSepFKIBfGDHrjlWCW3QJGHxNUWxUdMmauCRJMUNRAwR79D3d+gRMgZN3/ZQBa+IDidTFm4AkACHE4yM9pyRJUm+UcICg0j22vEYn1oDsiQ/XRuBdIcQLkfBeqSjKFf09oLq6GkVROv/cf//9I2yCJEknCyUcINSj7xkwJeIIn7zrp4yoJy6E2Nzjpg3APcALfT0mKyuL6urqkTytJEknKUUNElSM3W4LW5KId7VGqUXRN6KeeGT0SlflwPyRnFOSJKkvOjVIuEffU9hSsSp+vO1tUWpVdA07xBVFKQRWR8aRdyWHGEqSNCYUNUioR09cb0sGwNVwcn7CH3aIR8aD3y2EcHW5+WrggZE2SpIkqTd6NXBciJvitan37uaTc+r9QJN95gMrgCsiX9+FdiGzoxb+QuQ2gGRgtRydIknSWNGpQcI9QtySoK1k6G0+ORfBGmiyz2a0mZgP9nF/eV/3SZIkjTadCBLWdY8tW5I29T5wkq6fIif7SJIUMwxqELVHTzw+ORM4eRfBkiEuSVLM0IsgYZ2p223xCUkEhR7RfnKunyJDXJKkmKEXIVRd9564otPRojjQn6Trp8gQlyQpZhhEENEjxAHadE6MMsQlSZLGN4MIovYopwB4DAlYgq4T36BxQIa4JEkxw0AIoT++J+4zJWILu058g8YBGeKSJMUMA6FeyykhSxIO9eRcP0WGuCRJMcMoQgj98eUUNS6ZBOEmHApFoVXRJUNckqSYYSLYa4jr7CnoFIGr8WgUWhVdMsQlSYoJQlUxKSHoJcQN9hQA3E0n39R7GeKSJMWEUEjbJJleLmyaEzoWwZIhLkmSNC4F/F4AFIP5uPvSCmYREHq8a5860c2KOhnikiTFhFDAr/2jl3JKWnYBm3NvYmHrarZ/+OIJbll0yRCXJCkmBINaiCu9hDjA3C//nEO6bFI++gEe98mz56YMcUmSYkJHT1xn6D3ELXE23Ct/S5aoY/vf7j6RTYsqGeKSJMWEYMAH9F4T7zBj6flsjF/B7KMvnTRjxmWIS5IUE8Id5ZR+QhxALTgLq+KnqnznCWhV9MkQlyQpJhwrpxw/xLCrlOLFANTtWz/mbRoPZIhLkhQTQkGtnKI3Wvo9LnfKXPzCSOjI1hPQquiTIS5JUkxQgwEAdMbeL2x2MJrMVBoLsDfvOhHNijoZ4pIkxYRwJMT1xv5r4gDNCdOZ5C9DqOpYNyvqZIhLkhQT1JBWEx9MiJMxh3jaqancN8atij4Z4pIkxYSO0SkD1cQBkiYvAuDo3rVj2qbxQIa4JEkxQUR64oYBauIAudMWEBR6/Ie3jHWzok6GuCRJMUENaTVxg2ngcoolzsYhwyRsjRP/4qYMcUmSYoIYSk0caHRMJ8e3d8Jf3JQhLklSTBCRnrjRNHBNHEBkzCaJVuprKseyWVEnQ1ySpJggwh3llMGFeELhQgCq90zsi5syxCVJig2RnrhpEDVxgEkztOn33sNbx6pF44IMcUmSYkJHT9xkjhvU8VZ7As040Lkn9ubJMsQlSYoN4QBhoaA3GAb9kFadE6OvcQwbFX0yxCVJig3hAEEGH+AAbkMicQEZ4pIkSVGnhINDDnGfORl7yDU2DRonZIhLkhQTlLCfoNL/WuI9BS0pONXmMWrR+CBDXJKkmKCoQUJD7IkLWwoOxYvP2z5GrYo+GeKSJMUERQ0SGmJPXO9IB6C57shYNGlckCEuSVJM0IUDQy6nmBIyAGhrnLjDDGWIS5IUE3RqkPAQyynWpEwAPM01Y9GkcUGGuCRJMUEngoR1Q+uJ2yMhHnDJnrgkSVJU6dQg4SGWU5LSsgFQ2+rGoknjggxxSTpJqeEwpetXx8xSrfphhLjFasct4sBTP0atij4Z4pI0wYWCAdY+80M2v/VMt9s3v/EXpr1xBRtf+1N0GjZE+mGUUwBcOidGb8MYtGh8GPAqgaIoTuB2IFkIcXcv998FlANJAEKIx0e5jZIkDVNzfQ1Vf7mGJf6tNFQ4CS2/rnN7M+OuVQDkbnkY37k3YomzRbOpA9KLEOowQtxtSMTin7hT7/vtiSuKsgJYARQBzl7ufwAoF0K8EAnvIkVRrhiLhkqSNDSVezbh+8PpFPt2sd55ASm42PnxSwA01VVR4t3EbuNMMqhn64sPRrm1AzOIwLBC3GtKwhZqGoMWjQ/9hrgQ4l0hxAuAq49Dbo/c3+GfwNdGqW2SJI2A56U7MeOn8pIXmffNZ2gkAbH5bwCUffAcBkUl7ksPs82yiBn7n6ClsTbKLe6fQYRQdQNvktxTwJJCgtoyBi0aH4ZdE1cUZX4vN7vQeu6SJEXR7rVvMT24m7Jp32TK/DMxmsyUZVzITPcaGmuPEL//FQ7q8igoOYX4i36JXXjY8/x90W52vwwihBhGT1y1ppIg2ggFA2PQqugbyYXNJKDnZ5SJ+5lFknrR0lhLS9P4G/kQ+vA3NBHP7Ivu7Lwt88xbMCph9r9wH9ODuzmadyEABSWnsDHxfOYffZ7KPZui1eQBGQgOq5yic6ShUwSu+ok54WckIe7s647IxdBeVVdXoyhK55/7779/BE2YeBprj8TMkC8Jqv50GZWPXxvtZnSzf9tnzPZtYG/BV4izOTpvz5u+gL2GaZxSr1VA8864ofO+omsfwqPE4X3xDsKh0Alv82AYCYJ+6OUUY3waAC0NVaPdpHFhJCHuIjIipYueXx8nKysLIUTnHxnixzTX1+D44xy2vf/PaDdFGoT2NhdTArsp8u4YV8HXsvpB2kQcJZd87/j7pl0NQKlxBlkF0zpvT07PoWzej5gW2sOGVePzIqdxmOWUuMSOqfcTc9bmSEK8ieN7404AIYRrBOc9abU0VGFSQvjqD0a7KVIfdq95kzV/vgOhqpRv+QiDomJTfBwu2xrtpgFweP8O5rV9xM7sq4h3Jh93//SVN1GtpOOefdNx9y286OtstyxidunvqKncewJaOzQGQohh9MTtyVkA+Cbo1Pthh7gQYjPHj1pJAt4dSYNOZv72VgCEvzXKLZF64/O243znWyyteY7ynWtxl33ceV/9ns+i2LJjjnzyHADFFx7fCwdwJCSRdd8+Fl50/CAyRacj9do/AND83Ffx+zxj19AhEqqKSQmDYXA73XflTNWm3ofbxvfom+Ea6YzN53uMC18J/HmE5zxpBX1u7R/+tug2ROrV1n/+kixRhyoU6tb8HUfdRg7oC2nFilo1Pi4IJlR/SrmhkJSsvGE9PjNvKrsX/5IZwZ3s/P21qOHwKLdweAIBn/YP/dDLKXaHE78wgnv8XYAeDQNN9pkfmZF5BbBCUZS7ug4tFEJ8DShUFGWFoii3Awd6jBuXhiDk1UJcF3BHuSVSTw3Vlcw++Be2WE9lh3URBTVvUejbQ33SAirNU0l27Yx2E3G3NlMc2EN92rIRnWfhF29j7eTvsMD9Iesfv2OUWjcywYAfAGUY5RRFp6NZcaKfoFPvB5rss1kI8aAQoijy58FIGaXrMQ9GJgU9Lqfcj0zIr4W3PihDfLzZ//7TWBU/KZf+muD0y8mgAavix1iwDHfKXPJDB/F5ovu+7d/wNkYljKNk5YjPdcp197E29UqW1P6Ddc9H/0Knz62VGBXT8JYGaDUkYp6gU+/lAljjiBoppxhCE3c/wFhlrN3GUVLILZ7D9LOvwSu0HmHe/OXE5S/GoKhU7Pg8qm30l67GK0wULxz5fDtFp2PR1/7EtrjFzNv1AAe2R/e1NddWAmBOzB7W4z3GJGzBiTmNRYb4OKIGtPA2hmRPfLxJc5dSY50KgM3hZGficg7oC0nJmEROiVa+cO1fO+TzClVl48OXs+7Rr9BUN7JxzBmNaymLm43ZYh3ReTroDQYmffVZXEo8ppdvwd0avV3j3fWHALCl5Azr8QFzEvHhibnrvQzxcUREyinm8PgZFXAy2vDKH7oNsWt1NZIrqvGlzuq8bc43niHzux8CkJKVR7WSjvXwxz1PNaD92z9jYeu7nNL0Kvo/LqJ043uDfmxDdWXnCJKjh/eTpx7Bk3vGkNvQn8TUTOrP/QNZag2lf7ktahPRAs3aL7jE9OFdsA1bU3GK1nFzoXY0yRAfT4LaD6RFleWUaDm8fweLtv6Qqhd/2HnboV1aKcGWv6jzNpPZgtWe0Pl1Zdb5lHg3Ul9dMaTna/rsGfzCSOn5q1DR0f7R7/s9Xg2H2fHRS2x94DyS/jyHg79dTnubi8Mb/g1A+twvDOn5B6Pk1AtYn3cbC1tXs3fzB6N+/sFQW6sJCR2JacMrpyiOdIxKmKb6iTdrU4b4OKKLlFOsQvbEo6Xq8+cBmNnyEa0u7UKY++BGAHJKlvb5uJyzvopeERx476lBP1fA72NK/dvsdCxj2innUpZ4BlNb1+D3eWhvc7H+hYe7zQQVqsq2317IrA9uJte7h43JFzI5UErlYxdi2P8WDTjJn76on2ccvhlfuouQ0NG85bUxOf9ADO6jNCqJ6A1D2yi5g3PyKQAc2vr+aDZrXJAhPo4oIS8AVuGNcktOXomH3qYZBxYlSOl7zwJgrN3OUVI692vsTW7xHEoN08k4+FJnyUGoKgd2rGX9y4+y7vmHOofJddj54SoSacOw4HoATDMvxq542bv2Tbb/414W7/wpOz54vvP49aseZJ7nc9ZM+hr2H5Sy+FvPsXXxg0z172Se53MOJixG0Y3Nj3RCUir7TDNIPTr0ktFosPjqcBlShv34ojmn0y4sBPd/NIqtGh9kiI8jHaNSLEqQgN8X5dacfOqqDjI1tJfS/Oup1OXgKNUCNM1dSo1t2gCPhpapV5KvHqZs6ycA7Pz0NYpePI/F237CKbt/wc7ffamzhq2Gw5g2/4UGnJScdgkA05ZeiEeYCW18htlV2vo5/j1vAlBZupk5u3/DNssiltz0686Llwu/eBtbFvyKkNBhKLlkdL8hPV9fzllMDh8YcsloNDiC9bSb04b9eKPJzH7rbDKa1o9iq8YHGeLjiD58rAfuaXNFryEnqYOfasGZteQqqvMvY3pwN+tW/fa4i5p9mbbiRvzCSNMabeMFz/ZX8Agzh677iHXTfsA8z+eU/ff5VB8sZd2T32GmfysHpn+zc7s0i9VOqf0U5rs/Jg4/+/VFFDR9ilBVXP/6AT7FTPZNTx3X21548TcIfL+CeedeP8rfke7SF1wMwME1r4zp8/QmSW0kaE0f0Tm82cvIU49E5ZfQWJIhPo4YZYhHlf3AG1TqcsibNp/iFbdSRxKn7PqZdl/B4gEfn5CYwm7bYorq3yUcCjGp4RP22hYwacpcTrnmHjbM/SWFvj2kPLOMpdXPsi75EhZf+f1u51CnXgDAlvizaZp5M2k0senfTzDHu449k64jJWNSr8/d9SLrWCmYsYhakjGUn9jlkTzuFuLxoDqyRnSelFna+PnKjW+NRrPGjeFdJZDGhKnL0EKv2xW9hpyEdq95k5LANtbm30Ee2rDB4A9LKdu1jtaaMuadNrhSRbjkUlI3fMa6F3/DKdRzuOjYtPVFX7qTukVfpPL5H6CIEPO/9sRxverpZ1/L+vKPybnkPkxxNtStP2H6xnvxYWTqhd8ZxVc8dIpOR0XSMkoaVxPw+zCZLSfkeRtrKrAChoTMEZ2noGQJLS/bUA9+DHx9SI8VQiA8HtRAAENiIgCezZsJ1Tegut2o7W7U9nYM6Rk4L7sUgJp77yNYVYXa3o7q8ZBy5x3En3vuiF5Db2SIjyMm4cOFHSduAp7uewKWbnwPg9HC5DkjWxdDOl44FML87j0cJYU5V97TebvRZKZ43hkwb/Bjr6efcSXe9T+kZPfvQIGCpZd2uz8tu4C07/a9XrzN4WTxd/7R+fVe4xSmhvayLvkSThnm8LrRZJp2HvbPX2XnhneYedrFJ+Q5W+oOkQvEJQ9voo9QVVS3m3BrKwcDJeS4tNFG7k8/I1B+gLDbjdrmRnW70dlspP/gbgCq776b9g0bUN3tqG43qCqWmTMpeGEVAEd/8Qv8u/d0ey7rkiWdIR6qq4uc04o+JRmdbXhLBgxEhvg4YlG9NOuScapuAu3dQ9z8xndxG5NhTnTG6U40QlU7e8EbX36EU8IH2bTot2R02QlnOGwOJ5sdS5nv/oj9+iImZ+WP6HxNk84jdKCMzPP+34jOM1qmLL2QwGffxr39NfZa7DTv/gDn9DOZtmjsttb1NR5BCHDYUwgcqcKYnYWiKHh37sK3exdqayvhllbCra2oXg/ZD2prvdT+6te4XnkFta0NIiOGjHEmsi6ppfpgKerzz9P2zjsAKHFx6Ow2zPkFnc9rys8HRYfO4UBnt6G32zFmHvs0kPWrXwGgt9vR2WzorFYU07EFunL/9D9j9j3pSob4OGLBT60xH/yVBD0utv96OcFZ1zL3vJvIDldRqQx9GU7peOtffoxJ2x7Be9U/0On0zNz5ILvNs5h//ldH5wlmXgZrP6I+62wmj/BUC67+EdWVlzNpytzRaNmI2RxOdlhms6TueXhdG73TUP4srcWbe92Eoj/htjaCR44Qbm4m1NxMuKmZcHMzSV+9Gb3djuvFF2n667PEVR+i1JMJ/7yFA8CUjRvQ2+20vvEGTU9FxuUbDOgTEtDHxyNCIRSDAfP0aSQEv4guIR59vHZfo7sBDn6fqi1vM++n95P585+hs9lQehl/nvKNb3T+WwhBSIQIhAM0+5rxh/0YJiWTEqcNe9xevx1vo5dAOKD9UQNk2jKZmzYXgGd2PsPSrKVMTZo69G/6AGSIjyNxwofPkgp+CDaUs9C3kU177BydvoxsJUScKtdUGQ22Pf8kg3oanr8Cr2LFp5hJvuGvozbGuuSsq1hTuYnJ5//HiM9lMlvGTYB3MJzzA9ZtfB5DwakYrU5mfnAL6/9+NwuvfZBQQwPGrCz0dju+vfto+de/CDc2EIoEdLi5mZw//hHL1Cm0vv46R3/6s+4nVxTiL7yws3drzM2lzeAiWTQTd+G96J1OwjrwBtzovnI5k79yPfr4eCqCtTT5mvCH/VRUfYQ37MU8z8bKL/0EgFX7VnGo9SD+kI/W1gyaG/5JyUGFb83/FgA//vTHHGw5iD/sJ6BqQTw7ZTYPnqn16s9/6Xyq3N1ney6ftJzfnf07AO547w5cfle3+y8qvKgzxB/b8hh2k12G+EQW8PswKWFC1nRoAUv9DgBSPAdorNxFNmATcjr+UPm87bQ21REOBcjMm0pbSxNT/LvZ7DiDAvdWMtRayr7wd2bkFI3ac5otVpZ+7bFRO1+0CCFQW1sJ1dcTamgk1NBAuLGBwmXLMN/xJN4dO6m59172VE4iwfspZY9p12ty/vQ/GE9bQt2hUtzP/Q1jSgoN2Q7q8s0E5mazw/UpgdItuCfVceWjj2BISuLNwBbWe/bg14XxlT+Ab58PnaLjqT88Rf1DF/FInJ1P457A1+4jtOo+ANLi0njvKm2tmd+8+xs+qfqkW/vz4vNYmacty/vmwTfZUb8Ds8GMYovDrLZgbTm2DaJRb8RhcpCsT8akN2HWmyl2Fnfef/3062kPtmPWmzHpTZj0JnIcx2r0D5/1MABmvRmz3oxRbyTBdGzE0CfXfIJZP/RdiQZDhvggqKrgo7J6zpqSiqIoY/IcXncLJkCxp6IKhcx2bQGm7HAVNYe3AWAXnm61XKl/LY21KI/NJQ1t1M/WZf+DUIPMU8JYln0TT3o+tQ1HmLF45OtvxyIRCODdtYtQbR3B2qO01VXR2liDcvapiPklNJeX4rjtPuICcCADNhXr8JgB/XzCVem4Wxq4I9tJfNFKXhOv8/wUI4E4M97Kb6NWajXoTzd8SoI5gdc2PczTO5/Wnrj02JYEN1y/GaPeSNXmz9lWs5s4QxwWvQWLwYLNoF0ItPnryDPaSZn8JSwGC2a9mThDHPGm+M7z3DHvDm4ouQGL3kKcIQ6z3ozVeGw1xyfPfbLzZ3ft33/GkrLfUn/Btzvvv2/pff1+r66f0f8Y/EUZ/S930LUto02G+CCsLW/k5qc38Oqdy5id4xyT5/B62kgAdBYH7VjIQNtKyqCoOA9r43KNShiPp+2EjAmeCMo3rWYeHtbm3EJO1RvEr3mAhoQS2kQcxQvOwWgyQ+H0aDdzVAgh8IV9tPhbaPG30BpopcXrIn9TNQl17ZQ1lfGqcRfuoJtgdgr+zCTcvlZu/t0eCo/CxzMVfn+RHtKAox/CG9p5H//uTRSlzmSTYRcv1P4Nm8GKzViNtcmF1Wgl9YFHyLBlYFml55zaVbiTFzKpcB5WoxWrwYopshPPlcVXclbOWZ23d/xt0GkR9K353+osbfSUEGrgFLGQRYvv7vP1lySX9Pv96dr5Spp+BpT9lkNbPyA16+bBf5NH4NC+rRzd9TEzln8Fe3ziqJ5bhvggtHiD3f4eCx2bJOssdrxKHA68+IURsxJkWnB353HuliYZ4oPk3/8xPmFk3vW/YMc7U1i4+W5ymw6zw76M+aax+Wg7GkJqCJffRZOviURzIqnWVJp8Tbyw7wVa/C24PE20ht20+lu52jWFBYdNbGndxfeLj9/n8/+9rmfJDj/VMx18fJ4fq2ok3uAlHshwZJH1o8spyF2AzurF0LIZh8mB3WjHbrJjN9qZljQNq9HK1eq5XMv30Ov0vbb5xkt+TviXT7FVb2bJFceHcW58LrnxuUP+XqjhMMmimYO2kc3W7Kpg5lK8/zIRrPgcODEhXrVmFUsP/h7X6VeN+rlliA+CL6StQewNjN1axIHI/poGiwOvzgZqE3vj5jDNuwWTEsYjzFgVP57WRsguGOBsEkBK40YOmGdQYrEy74Jbqdz6GHnqEUKFy094W1Shst+1n2ZfM82+Zhp9jTT7mpmTOofTc06nydfETW/dRJOviVZ/KwIBwNeNK7hsXwKHmsp5bMEWLAFwqCaSMgtIMCfQtvpdmjc2kVKQxk36HBJsyaQWzCDjtOUkmBNIP1tPQkYe000mruinfVOBqczr836jrv+RUUaTmXJjEfHNo7vXaFN9FSlKGF3CyGZrdmU0mdlnnkpy05ZRO+dA4o5u1GYDp2SM+rlliA+CL6jV97zBMQxxj7bDvcFiw6ezggqehMkcCTRQqFZQYSpmRnAnvraJuTvJaPG4W9AbjPi8HgpD5azLvg3QdqlpXvojHJ/dTeGyy0bluUJqCG/Ii8OkjS1/cd+L1HpqqffWU++pp95bz2nZp/Ef8/4DVahc8eoVneEMoFN0XO9YztR/bsBdVUFWagNTG704hZ2i275FoiWRhAefpW3TGpKzM/mXOB1rRg6WadNwXqy9hvCpbejsdhRFYWFvjUwalZc6KC5nCTPr/004FBr2krE9NR+tJAUwJQ5vok9fWlMXsOjIs3jcLWP+yVYNh8n37mSf8wyGt6VF/2SID4IvEt6+MQzxkF8LcVNcPH69DUKgJBfR5G2gsLWC1qRZULsTv/vkDfFQMIBeb+j3wu6R360gpJgILL6DuYogfupZnffNXXkdrLxuUM8VVIPUe+rxhXwUOgsBeHTzo+xr3ketp5Y6Tx3NvmbOzD2Tx87RRqL8YesfaPA2kGhJJDUulRRrCgnNQRqffJLAocP8yDMZc00T9jo38/71Nk6zk9of30vja89gysrihzkzMObmYC4oIGnaNQCI353dbQJJT3rHyCYnjSZdzgJsDS9SWbaNvOkLRuWc7fWHAbClDL0U0x9r0TIMVc9Quu1jZi67aFTP3dPhsm3k4UaZtGRMzi9DfBA6e+JjWE4JRcop5jg7boMN/GDNmIrb1wat72LMWwS1/yDYfnKGeF3VQSxPnIpBhKky5OI788fMOqP7lPbDZduYEtoHQO1nPyYgDBTNO7PX8/lCPqrcVbj8Lhaka4Hz2JbHWFezjpr2Ghq8DahCZXrSdJ6/SJvUsrtxN/XeejJsGZQkl5BqTWWyMRv3J58SqKzkD4eWYT5YjVpxmPznn8CQmEj9o49R98ffoHc6WTxpEqacBRgX5JKod6DT6Un/4Q/J/PnPUPS915r7C/DxJm3qEtgKdXvXjFqI+5uPAJCYMbp92Py5Z8PH0LbvUxhGiAcDfrb+8UbIP42FF3+z345F7a6PyAPSZ/b+f3GkZIgPQkcZxRscu/0FVb82BtxsiydstAOQmj+DzCnzWPNmgOK5K2A9hD2uMWvDeFb+r/9iofCxKfVSshrXUPTezazZ+xFLbnm48wfoyOf/JBfYaZ5LiX8ray3TsbcfZJZVW0b273v+ztsVb3Ok7Qj1Xm30T5IliY+u1jYKaA+2YzFYWJq5lEx7JhnWDCbFTyLU1ETgwAF+5VpOsLISf0UFaf/vBsyFhTSvWsXhn2glG53NhpKXR9ysWYhAQDv/DV8h6aYb0cfH0xu9fWzW04iGnOI5tAsL6pHNAx88SGprDSGhIyltdMspCUmpVOgmYas9/mLwYBzY+jGLXG/C1jfZeOB9pt76FxwJvdeulMPraCae3MmzR9LkPskQHwR/R4gHQgMcOXzhyCbJFquDUFwy7uY40rIL0en1pNz8AD6vFvLC29LfaSakhqOHmFv7MlsSz+OUO5/C297GxiduZ2nV03z2+mSWXvRNdIqOiro3eSa9gPqMRA65cvHr2uGN69jw5Q1YDBY8QQ96Rc+y7GXk2HPIdeSS48hBCK1O/b3cG/EHygkc2I91yVIsU6bg/vQzym49tuiYYjRizJtE2OUCwH7mmeT97VlM+fnoU1KOm0egdzpP1Lcp6vQGA5XmYpyu0bu4qXcfpUlxkjZKNfauap1zmd70Lmo4jK6PT0J9ad6lDftdk3UDi6qeo/6/F1O29D7mrfzycb3yjJZtVFhnMm+M5nfIEB8EX2dPfOzKKSKyv2acPZ5pl/2Yo9XXMbnLfyxLnA2/MCL8J1+I73/l1ywihFhxK/8o/QcVLRWUT7fzgyOTqG/+M6uOnkW8z4DQ1VFmzWWaI4tTspaSG6+FtE7Rfnhum30bt5Z8leCRI1oYZ2URrK2l4qqrCZSXo7YfmxGb/sN7sEydgmX6NNLv+QGmwiJMBQUYMzO6lT6MaWkY04a/48xE05o4k3lHXyAY8Gvj8EfI5qmi2ZDKWHyHdZOWEN/0Kgd2raNo9qlDeqzj6FoO6AtYevtjlK6/GPNb32P+mjvZvuVp0r78OBm52qo55TvXUSiqOZLR39igkZEhPggnYnQKgXZCQofJZMGcaiUx9fi1k9sUGzp/69i1YRzwh/0ccB2grLmMsuYydtRs5c6m99mSsJxWB/zXh/+FzWijIL6AackLuObgexz+570kYOa6NjdnXvo02V0m8IhwmMa/PIl/3z78+/cTOHgQEQiQdOONpN/zA/SJiegddhIuvRRzUSGmoiLMRUXok7SPxobkZJJuvDFa346YY5i0AHPtP9i/Z+OIl00Wqkp24AD7ks4epdZ1V7DkYkJbfkzd2v8bUoj7vO1M9u1ia/plFAHTFq8kNG8ja194iJmlj9H61PlU3/g6Jksc1he+TD2JTF5xy5i8BpAhPijHxomPXU1cCbTjUSzE9/ORy6OzYQhMnBBvDbSyp3EPqdZUChMKKW0q5ZrXryEstO+3WW8mww8eHUy5/L+YkZXLe1e+R2rcseUPNvzuGubXvYXfZWSPuwjnX/9Jxb59mIoKyfrFL1D0epqe+xuK0Yi5uBjbqadinlxE3Jw5AOhMJiY9Nfgd6qX+ZU4/FTZA4761Iw7x2qpyMnAj0gfeGm84UjJy2R63gILqN1DD/z3oksqBzR9SogSxTDn2y8VgNLHk2h9RtuV00v51Dd5nLsClTyBLtFJ16YsUj3BJ4v7IEB+EEzHEUBfy4MNC75e/NF6dHWOobczaMNaC4SDP7XmO3Y272dW4i8Nt2vCxW2bewncWfIdJjkncOutWihOLmZI4hfZdu5n5znWsyb2VzLypqIEAukNNtO5bS9jtJum665j99acou+wyRHkl4KW19E3MU4ox5Ry7EDZ59Wp0lhOzC83JLit/Oi3YUGpGPpHmaOl6MoCEwtEZ6dKbQMmVZGy6i11r36Jk2RcH9ZjW0vcJC4XChcfv0lM87wwO6F8g6aWrSAuVs23Z75k39/TRbnY3MsQHwXsCyin6kAe/0n/Q+A12zKHxvxytKlQOthxkW/02ttZtJd2Wzh1z78CgM/CXHX/BbrQzI3kGl06+lJLkEkpStHUvrEYrd867E4Dd775I2qf/yVFSKAhMpvyii/AfrICQdnFZn5xM4rXXYrZYybn7HlAUzFOmYEhPP+7iogzwE0fR6Thknkpyy64Rn8t7eCuqUMid1us0plFRcs51tG+8l/YNz8EgQ9x5dA0HjMVM6WP99KLZp1JlX011TTnzBnnOkZiwIb6pson/9/w2/v2t07GbR/YyO3rgnjEcnWIMtuLV2/s9Jmhw4AwcHbM2DMbeje+TlFVIapePhyE11LmQ0c/X/Jy3Kt6iNVL2cZqdnF9wPqAtQvTOFe9gM3YfVheqr6d1yzv49uzBv6eU1i0b0LW047/CTODqZ3BuKsWYk4t9+XIsU6ZgnjIFU15eZ1jbzxyb8bfS8LiTZzG96m/4vO1Y4oY/hNLSuIsqXSa5DufoNa6HOJuDDc6zmN78AT6PG4u1/59Bj7uFokApm7Ku7fe47MLp3a7NjKUJG+IPvLWXykYPO460sLRoaDuO9OQ/AePE4wN1NMXl93tMyBSP1T34NcXXPPEdnHXrmP6jNSNsnWb7By9Q8uGt7DCXUH7zw6w/up4NRzdQ017DO5e/g6IoJFoSWZm3krlpc5mbOpe8+GNhK4JB9OVHcO3eg790D0k33ogxK4vWd96h9ue/AJ0OU2EhFmcbwSILCd98nfisXJi1hOSbbhqV1yCNPUPaVAzVKjVH9pNbPGfY50n37KPGXsLoztU8XtzC63C89xabPvg/Fnzx1n6PPbDpPWYpYWxTzxnjVg3ehA1xk167QBgMjzx4O0an+MZwxmZyuIFa6yn9HqOa43EMYWOIjJoPyAtXDqqH0Z9gOMihvVso+PBOno1P4PdJLQTeuRWdoqMkuYQLCi7AH/ZjMVg6yyGq3w+hkLYX4q5d1PzkJwTK9iOC2kqQisWC/cwzMWZl4Vi5krjZszEXF7P9k5eY+9k32LzkES3ApZhjTc0HoOVoxbBDvKW5gSxRR2XK6K/619P0pV+k7r0k9DtXwQAh7t77IUGhp2jBiV9ErS8TN8QNWoj7Q6MQ4qGxHSfubm3GoXgRjgFWarMkYFaCg/qY2upqJC9ciU4RVO3fPuRxsNXuaj6t+pRPqj5hfc16/rMugRWKgZRlP+eKdfeTop/Btbf/H3aTHaGq+Mv249qxHe+Onfh27MC3bx/pd91F0g1fweB0YnAmYrvhK1imz8AyfRqm/PzO8dZdx1rrNj1JHUnMXj64NU6k8ceZmQ+Ap6Fy2Oc4smc9CYBtUt8rK44WvcFAedoK5ta+jLe9jbh+NsuOb9jMQWMRU8awxDNUEzbEjXrtI3zrKKwBPtaTfRprKrEDhgFWatNZtNXW3C1NA4Z45faPmaVoMxGbK3fAIEO8oqWCb33wLQ5Gtq7KtmdzUdFFTKp4lnLHQi485Sukv/tvig58Sttbq7FffCnC6+XgpZeCqqJzOLDMLCH5q18lbt5cAIzZ2Ux66skBn/vw/h3M9m1kTd7XSTPGzpohUncpWdpSyeHIuifD0VahTYfPmt7/p9PRYpt5AZa659m27t/MOeeaXo8Jh0IU+PexI/XCE9KmwZrAIa71xEdjI4exLqe01mo9FmvKpH6P01udANqa4hn9lxrc+9egCgUVhWBtae/PG2jl4yMf8/6h95mRPINbZ91Kpj2THHsOVxRfwWk5p1EQX0Crq5HQf/+RqjYXZatOxeFyUUc8weoHybz4UnQ2GzmPPYqpsFC74DjM6cVVq39PhtBTfN43h/V4aXwwW6w04ETfVjXwwX3Q1+6kAScpA/w/Hy1TFp+H5z0zvt1vQx8hXlm6iULFj35S/1uxnWgTNsQNOq0nPhoh7h3jnri38RAACen5/R5ntGnbOnlbmwY8p61uM5X6SegIY24u63bfK/tf4c2Db7K+Zj0hESI1LpWS5BLCbjehnTv5xtNbUNtKMWR8ivL44xzZsx5HrRmDHuwrlhM3azb797zIQvUt9qx7m+mnnIdj+chqhN72NmbUvsb2+DNYkDUWqy5LJ1KTIQ2Lt2bYj09y76XKUkzKKLapP2aLlS22BUxq+KTPfWwbSj+jEEifcdoJatXgTNgQ76iFjzTEVVUQCKkYdAqhyL876u2jJezSPnYmZ/bfEzfbtRAfaE1xNRwm37eb0qRzMPhd6PwHeaP8DS4ovACADw59wJG2I1ybdj7nzr+K2amzqX/gIfb9dTEIgQEw2htodaYhhKCtYjMzzmyi8RsfkZKhtXFG27nUPLwI+1vfwT9nE2bLyDaC3fHWkyymnbhlXx/ReaTxwW1OJ9lbMazH+n0eJoUOsTH9jNFt1ACChSvJ3Pk5lXu39L6UbtVGXNjJKex/P88TbcKGuCdS+hhpiHf8MnBaTTS4/XiD4VEPcZ27hmbiSRygzm1P0tZT8dZX9Hvc4bJtJOo8fJKewDrPYfYqCuond1O06Si6z7fyld1bsVY3owTLmfzht9ApOqyLF6GLd9AUB0X7fkjAZMKvfEZjzSH0tTtoVJydAQ5gczgpO/WnzP3sG2z95BVtw4VhEqpK0u5nOajLY/ri42fBSbEnYMsi1b2+z15tfw7v3cJkJYwpZ/jDE4cjb8klsPOn1Gz8V68hntqyk0OW6cweo9UIh2t8tWYUeUcpxDsuaibZjN2+Hk1mTy1N+oE/OGYXzqCOJAyVH/d5jBCC9z55nLNyc3jG9zGNSoBbXa086rsc9ScPEXzvPVK9R1DOO4vsRx/p3BnGcc45pH7zm7Q4wxjMgr3LHsYm2jnw0v0kufdSbSk+7rlKzrycVqwEdr027Ne+4aVH2PXA2UwOH6Bu2leGXU+XxpmEbKyKn1ZX45Af2nxgIwBpUxaPdqv6lZ5TxAF9AY7DHxx3n7u1mbzwIdpT557QNg3GxO2JB7XZlSMO8cjwQqdVGy0xFrv7OAJ1tJkGXmxT0emodJ5CseuTzn0MRTjM3pYyXtzyHLnv7WLJB7XM9DWz8lQdp5XpmHrFNUxx3cum3HQK33iD2mcvYBKNlBo34ljxyHGhqdbuISAMzDr7KjbveZO59a+hQ2Vj+vHrPxhNZrbFn0qx6xNCwQCGIY4oKd+5jkXb7+WQLps12Tcx/+I7hvR4afwyJmqf2hqqDpCQlDqkx6o12/EIM9kFM8aiaf2qSz+DhVXP0epqJL7LtPqKHZ8yUxHYCsdmi7WRmLDdHo9fC9s230h74lo5JdGq9cTH4uJmUrgBv3XgXbDD7nb0FBPeA5tv/zKPfmMpl/11BVe+diUvVr/B4XAD9rPPJrMkwNUJeVz4+kYmXX8LqlAIuPbjcViYRDUHdXlMC+5my+q/H/cccS1lVOlzMBhNZF/0Y/SEMSphTNm9f7TVzbiIRNrYu+HdIb/uuq1vAGC55d8sve2REdfVpfHDnqZdnG6rqxjyYx2uUg6Zioa8UcNoSJx7EUYlzO43/9Tt9rb92qznvNlju5jVcEzIEH/0vTLKG7SZjaGwGODo/nX0vBM7euKjHOI+bzuJtKI6uq8frgYCeLdvx7NhA6DVjfefeSZxf3qBum3xPDBlD08scaOzmLln8T18cNUH/OiBTwjeeCW5kxsIzV+BYjJhsdo5YCgipeYjKrdHtiFb/kuqlXT0W/56XHvSvAdpsmkbA2cXTmeLc4V2+5Teh1VNXfYl/MJI29ZXhvzarUc+pVKXS1p2wZAfK41vSVna/yF/ZOTVYKnhMJMCB2hJmDYWzRrQ1IXL2W5ZyOzSRzhctq3zdkvtFg4rWSQkp0elXf0ZcTlFUZTbgQXAqshNVwIPCCHKR3ru4Xp49b7OfwdGOO1+rMspjTUVZAMGZw6t77yDZ+1avNt34Nu7F4JBLLNmkfGPv/JG+Ru88J00fpv7bdpX/4BrDWZmXPg005O7L7JzdNs75AFZc49dIGwsvJglZQ+zecvftSnDc89i17pZ5LZ2Xy60vc1FJvVUJE3pvK3wuv9mw2cvsrCo9zWdbQ4nW60LyKt7f0gXsXzedoq929mWdglyQOHEk5yeS0DoUV2Hh/S4mspSshUvSubY7Ec5EEWnI/OGJwk+firef95K8K5PURSFXM9uKuIXjfk6LsMxWj3xq4DVwAPAn6MZ4D2NdO2Unhc2hxLiQtWe+9C+rVRX7NVuE4JgVRWtb71F7YMP4br3ZwDEpUyi9bXXafnXq+hsNpJvvAHxmx/z/Dens3zVcu5fcz+BhDjccwpomHQqF7XtI99y/AxPw6HPqCWZ7MJj9cTCs25AFQrz3R9TYSwkzuYgmDKDdBppaW7oPK4q0vOwZB17bHJ6Dosu+3a/4RyYfD6Z1FO+c+2gvzf7N71HnBLAMnX8rEEhjR6dXk+DLhmju3pIj6vdp33yTCwau+VnB5Kalc/+xb9kSmgfBx46C/cvC0jBhVpwYoc8DtaoXNgUQiSOxnnGQnCE5RR/8NgQQxh8OWX9o9dj8LuYdfMzKH+/hrBOoaHgHpr+9GfCTdpkHcVoRE2NR82HzOL5OH95Fjq7HUWn42j7Ua554Vz0TXpW5K3g2mnXMi9tHoqisK34TEw1z7FzywfMPO1iQFsrZdfLDzKnbQ27nGeS3iV007IL2GWeTUlgG02JWm3bmlMC5VCzbzMJp2i9dlfldgCSC4Y2tGvy6VcS3n4/dRteGvQaLW273yUkdExe/IUhPZcUO1zGdKzeoS2d7D+8lZDQkTt1/hi1anAWXHAz68tWM635Q/bFn4q+5CIWrfxKVNvUlwk7OqVDcIQLYHX0xAdTE1c9Hrw7d+LbsRPH69swNPrY/+TpFHyhHoszxObDW8k46yziZs3EMms2linFbPzjDTS5DuNMzeCdytUcLD/IN+d+kwxbBj899aecln0aqdbuV/cLF6wg/JFC296PIBLipc/cyVLXG+ywzCfzovuOa1v71Ethxzb0edpaFOmTF8DH0FK5DSIh3jEyJWuIowKS0rLZbSohvWr1oI73+zxkHP2IMtM0pseP29//0gh5LOlktW0f0mOsTbs5rM+lYATrkI+Wxd/+XwCi95lgcEYlxCN18SYgCUAI8fhonHe4rCY9nkCYi+Zk8c6ukW2i0FET7zlOXA0E8JeW4t25E9uiRZiLi/Fs2MDhr2kzDhUbxCUF8U4xoTerHFayyA6+QmX6EozJ05k3U5v1ZXHv5amkTN576YtUt1dTlFDEbbNuw6g3cmnxpb22yZGQRJmhiPja9Z235bRsYrPtDOZ/v/cx27MvuJ21vjbmLv8yoI2JbRNxULcbgKa6KoqPvs5+0zRmDGPxqdb8c5lR9jBV5Xv6XQy/vrqCpqeuYqpawfpZvxjy80ixI2jPJrXlg87hsIOR6S2jMmEh8lL34I1GTXwj8K4Q4oVIeK9UFOWKvg6urq5GUZTOP/fff/8oNOEYIQTeYJhvnTOZ/GTriGviHZsjO60m7AEP2U8/wsHLLmfvgoVUXHU1tT/7Oe5PPwMgbv58cv/8J4o//4yEi4LkLGumeOoRDtnzaTnn1yQKF3Ob3sK59iEAPqh4n69lBfhbQjsZtgwePftRXrrkJYx644DtakxZSJF/D36fh4ajh8kStQQy+96L0BJnY8mX7+1c/VDR6agyFeBoLUOoKpXP3IZDtBP3pYeH9X3KXaqt+3x4zaputwf8Pra+93+UrnuHtX//KebHl5IbrGDzkkdYfOl/DOu5pNigc+ZgVMI01Q1uNcPG2iOk0UQ4beYYt2xiGXFPXAixucdNG4B7gBd6Oz4rK4vq6qFd7BgKf0hFCLCY9ITCAlVAWBXodcrAD0a7GBmoqMC3cyfeHTsp+nwjN+qzcMatwK83kbxlDbqZ00m+6SYsM2cSN2smhkxteKDe4ejcKiwOb+c56zPPZsnplyCWNfDOs99j6pFncTUcJb5F5VSvl4UZX+Ga8386pNdpLjodS+3/sXvrxwTamkgBnMVDWzO8xTGZqU3vs/GVx1jk+Yy1xd9lScnwlv7MLpzOAX0BmQf+ic/7vc5fFptffIgl+37Tedx2yyKcl/2G+VPmDut5pNhhiazK2VRd3m07v75U791AMmDPG/s1xCeS0RhiuEII0XWmRzkQtasSHaNHrEY9XrRedDCsotcdP3FAGylSTbixgbg52sW88gu+SKCiAgAlLg41u4BGSzxWkwGd2cSb9z/FPV8cuGZsFV52WOZR6NtD+qnXUuep4+mdT/O87iPmpSRxx+Z3EUEvv6lvpPzMC4b8Ogvmr4DPoWX3exDyExR68mcNLcRJm4Gz6VVmbvsFu8yzWHztT4bcjq7cp/2IOR/dytq/fp8lX/8jACkHXuaAvpD203+MKc7B7FPk2ignC0eaVhRx1w1uc4j2Cq0/mHuC1hCfKEYU4oqiFAKrFUVJFEK4utwVtSGGnkjN2moyEFK12ZqBsIrFqIV4+/r12ljsHTvx7dxJuLkZU14eRW+/BUDSjTegmMxYZs3EXFjIf39QzuvvlfGoQYfNbKB9EKNTAn4fJiWMO3MJrVf8g7/vfJKXX3yZsAhzft4XuOmTp2lWP0YYzASFnpxhbGHlTMlgl2kOUw79k0ZDOhXGQoqHuAWbPXc2lEIYPUlffnLEM+TmnH0l63a8yuKa/2X32ouxOdOYHD7A2in/yZKzLh/RuaXYk5xdBECweXATfgz1uzhKKhnjcELNeDaiEBdClCuKcnePAL8abbx4VHgjO9JbTPrOi5JdR6i0/OtftLz8CubJk7GffXbnSJEOidd238XaHwxjNujQ6RTsZgNu38A73nvaXJgAxWTnzYo3ebHsRS4puoRbZt1CriOXXZ99TnrDWoI6M0f0uRSYLcN6rcYv/IzkVy8hOdTCutQ+L0P0adLMpRx5N4Oji/6ThXlTh9WGnmbe/BjVD68n5a1vUJG0jByhMPmcG0fl3FJsiU9Iol1YoGVwNfHU9n3UWIsZeAEKqavRGJ3ygqIod0X+nQysjubolI4LkVajnvbOzZKPjRVP++53yfjRj9BZB7dOhy8Y7uzF280G2gYI8RZ/C49t/wOnWONItDi4Zuo1nJ9/Ppn2Y9PqW9MXU3L4CVBh/az7h30lfsr8s9j8/pnMd3+EftLQV3xzJCThuG8v/W8KNzQ2h5Pay58ledWFLG56jR2W+czqsoStdPJQdDrq9amY2gfeHKK9zUVO+AjVyXLewFCNxoXNcuDBUWjLqPBEeuJxJn3nFm1dR6gYUoa2V4gnECYuEuIOi4E2f+8h7gl6+Nvuv/HMrmdoD7YTbzZxmiUeq9GK1dj9F0bG0qs5cuQ1ahf9gMUX3Dyk9vSUeeVDbF71fYpP/dKIzjOaCmeewsbyn7Nw890EZn852s2RoqjFlEG8b+CBDAe3f8JMRWAtlPXwoZpwk306auJaiGsjUkayfoonEMZmPhbi1S7fcce8Xv46D214iCZfE+fknsMXjQs597072R7X+67ZBTMWwSj1gDPzppL5n6+OwplG18KLv07D4i+y4ATtkSiNT974Qoprt6OGw/1ec+lYJTB/9vic2j6eTbhVDDs2M7aa9Jh66YkPldsfwm7WftfZzQba/NrF0pAaIhAOAKBX9BQnFvP3C/7OI+c8QqaqDa8zWnsP8ZPFidrkVhq/lNQpWBU/ddUH+z0urnYzh3TZ43KVwPFuwoV4x7ZsccYu5ZTQ8NdPafeHsEVC3GEx0uYL8NbBt/jSv77Es7ufBeAL+V/gL+f+hdmp2gXSoLcVAJM1YdjPK0kTgT1bG45bf3BHn8cIVSXPs4va+OisXBjrJlyIe7uWUyJ7YY6knOKOhLgQApeyjWD6w3z/4+9j1BmZmqiN6FCU7hOJwj43ABabDHHp5JZeqC1h3F61p89jqsp3a2vqZ/e+Zr3Uv4kX4oFj48Q7auL+UJgXNx3BEwjxm7f38n5p7aDP1x4IYTPpeXDDg3zo+jXoAvz81P/ixYtf5PSc3nf5UH1tAMTZ40f4aiQptiWnZdOKDaWxrM9janZpe8amzTjtRDVrQpl4Fza7lFM6auLv7q7jqc8OEgyr/PnjA1w0O4tzpg1ce9vVsAt3sBmbOZULCi6gtjGelz7KZtk156JT+v79p/q1ELfaZU9cOrkpOh01hlxsbX3P/1MPb8At4pg0te+1f6S+TbyeeDCMyaBDr1M6a+KrNmq7i6wpbyQYFjR7Av2e44DrAN/94Ltc8+9r8NnexW42MCt1FqdnXATocfcxzLBToJ2Q0Mk9IyUJaLXlk+bve9ZmcvM2KixTB73SodTdxAvxQKhzXHdHiHeM7f60TNvFpsnT++bJVe4qfvTpj7js1ctYU7OGr83+Bt66FZ0XNu1mbXXBgWZt6gJuPErcoLcqk6SJLJQ0mTSaaGtpOu4+j7uF/NBB2lKjuwlELJtwKeMJhLGatBA3GY5dcLSbDTS2az1wVx898T9t+xNvV7zNDTNu4M3L3uT6qbeCaukS4trfbb7uvwRCYZUv/O5j3tqprV2uC7bjIW50X5gkxShLpra+fM2B40eoHNz2KQZFxVq49EQ3a8KYcCHuDYaJM3XviQPMm+Ts/HdzJMyPth/lV+t+xa6GXQD8x7z/4N+X/pvvLfweiZbEzrKJvctkH+C4WZtN7QFKj7bxzm4txPXBdvw6GeKSBJCUp60P3nJ413H3te7X1uLPn3PmCW3TRDLhilDeLtPku4b4/EmJfBIpp7SFGvjZmp/zyv6XEUJQkFBASUoJada0budq92sXSY+NE9f+7llOaYr07LcfaQHAEPbIEJekiKyC6QSFnlDd3m63C1Ul6fC7VOpyyJOTfIZtwoV413JK1xCfma2NFDGnvYEx6TNeLlO4tPhSbpl1C9n27F7P1dET76uccrChHZtZT1OkZ3+g3o3bH8IU9hDQy4uakgRgNJk5pM/A7DrQ7fZNrz/OwtBeNsz+GXlRattEMOFC3BsMEx+nXYA0dQnx/GQtVC16K77mxfzlsrtZklfU77naO8spkRDv6IlHbv/Gc5uYmuHgvBJt8UwhYMeRFjLCHrxGuQGwJHVotOSR5K3o/Nrd2kze5l9TZihmwSV3Rq9hE8DEq4kHwsQZtZdl7HJhMzfJSka8hXOzrsdfewkGMXDIdqyIaDNp4W026DEZdJ018aOtPqqavZ09cYDtR1yYhZewQfbEJamDL2EyWeEaQkHtZ2XH/91LKs2Ev/DAiDcjOdlNuBD3BENYI6HbtZxiMepZ+8Pl3LA0H6Bb8PbFHamJd/TEARyRNcXDqqDFG6Te7e+8UJrlMFBdvps44SVstI3WS5KkmKdPm4JJCXG0ch87P32VBVX/y4aE85i2cHm0mxbzJl45JaB2jk4x9LI5cqJNK7W4+hgr3lV7Z038WE/BYdF292n1BhEC6tv8NHuC2Ex6HjX/D9mVO7EKL6ppaFulSdJEFp8zHbZB+H+vYaZ6mKNKKgVXPxTtZk0IE64n3nWyT8fCVNMzj61hkmg1AQw4axOOv7AJWl3c7Q/h8mq/BDyBMEeaPSTaTIjJK8mkHrMSBBniktQpc/JcAkKPU21ibdG3cd61lZQseTlzNEyonrgQAk/w2OgUgLe+czpZzmPD/TrWGW8eZE/coFMwG479ruvYZ7PrL4F9tW0k2UxMO/tafFvuw6IEUcwyxCWpQ0JiChXXvENiRj5LEoe2u5bUvwnVE/eHVISgc09MgGkZ8cRbjJ1fK4qC02rsc9ZmVx1riXddatZhMdLqC3Z7fGWTB6fVhCMhid12beaZznxybwghST3lT19IggzwUTehQtzbZVef/iRaTYMsp4S7XdQE7cKm2x/qVlMXApKskV8Usy4HwCA3hJAk6QSYUOWUjg0hBgxxm3FQo1O0nnj3cyVYtcf2LMc4I7X22cuvY11LLTNPu3QoTZckSRqWCdUT71hLvGs5pTepDgv1bf4Bz9ceODZcsUO2Mw5PIExFQzs6BfSRETBJNi3EDUYTp1x9NzaHcxivQJIkaWgmVIh33dWnP6l286BCvOsmyR1yErWLpDurW0iIM5Ji18I7MRLikiRJJ9LECvFBllPS4s20B8Kd48D70ls5JSdRm4m5p6YVp9VEqsMMQKLVeNzjJUmSxtqECvGOafIDllPsWvAO1Btv94e7jREHrZwC4AuqOK3GznMlWWVPXJKkE29ChfhgR6d09J7r3X2HeF2bj5oWL7mJ3ddAcVqNnedP7NITd8oQlyQpCiZWiA+ynNIZ4v30xF/bVoMq4KI5md1uVxSlsy7ujDOS5rAAxy5sSpIknUgTKsS77nTfn7RIiNe1+vo85pUtVczMjmdy2vGTdjpKKk6riVOLkllamNx5gVOSJOlEmljjxDtCfBCTffQ6pc9ySmVjOzuqWvjxF6f3en92pCeeaDVy6uQUTp0sZ6FJkhQdE6on3lFOGagnrtMppNhNfZZT1h/UduU+c0pqr/d3jFBxyhEpkiRF2YQKcU8gjEmvw6Af+GWlOSzU9RHiWw67cJgNFKX2vohV13KKJElSNE2oEPcGQgOWUjqkOvqe8LP1kIu5k5zoelmPHKAkKx6jXmFymlypUJKk6JpYIR4MD1hK6ZAeb+ZwkwdfpATTwRMIUXq0lbm5zj4fW5hqZ/fPvtBtnXJJkqRomFAh3nWn+4FcMjebVl+I37+/n1UbD3fO3txxpAVVwLxJzn4fbxxEyUaSJGmsxczoFCHEgMd4A+FBl1OWFCZz9tRUfv/BfgBe3VbNA5fP5g8fHkBRYE6OcyTNlSRJOiFiJsRveGo9n5Q1DHjc4vykQZ/zZ5fM5K+fV5BoM/HQ23s59dfvo9cp/OySmSRHptNLkiSNZzET4pfNz2ZBXuKAx51ePPgx27lJVn584QxAu1hZ2ehh3iQns2UvXJKkGBEzIX7pvJwxPf9ZU9PG9PySJEljQV6dkyRJimEyxCVJkmKYDHFJkqQYJkNckiQpho3bEL///vuj3YQxJV9fbJOvL7ZNpNenDGYSzWhauHCh2Lhx44DHKYoyqAk+sUq+vtgmX19si8XXpyjKJiHEwp63j9ueuCRJkjQwGeKSJEkx7ISXUxRFqQcqB3FoFlA9xs2JJvn6Ypt8fbEtFl9fnhDiuJ1qTniIS5IkSaNHllMkSZJimAxxSZKkGCZDXJIkKYZFbRVDRVHuAsqBJAAhxOOjeXw0KYriBG6PfLkIWN1fexVFuR1YAKyK3HQl8IAQonws2zlcw2lvjL1/q4A/o7W3qet9QghXL8eP6/evy//HZCHE3b3cH9M/i/29von+swhoO+ac6D/AA8AVfX090uOj/QftTe/69QHg9n6Ovx1oBgSwCZgf7dcwwOsbUntj8P07EHltPf/02ubx/P4BK4Ar0H4p/Xmk7814ey8H8/p6eW8nzM+iECJqId7c4+v5aL8hR+X4qH5DwQms6nHbXcCBfh7T53+q8fhnqO2Npfev4/0azG2x9P5Fwra3kBvSezNe38veXt/J8LMohDjxNXFFUeb3crML7TfqiI8fJ1YoilLY5WsXUNjHsRNajL5/3T5uK4pylxDiwWg1ZqzIn8WJIRo18SR61Bl7+Xokx0eV0GqmPfeRWwm829/jIrW4JsZJnXEgQ2hvTL1/0L3urSjKCgZ47yLHxdT7FyF/FnsRa+9lNELc2dcdiqI4xfEXjoZ6/LgSubCyAljez2EbAZeIXDxRFGWVoihNQogXTkATh2Mo7XX2dZJYeP+AK4UQXxvgmFh7/zo4+7pD/izGznsZjSGGLiK/4brob4v6oR4/3jyBFgSb+zpACLFZdL/6vQG4Z8xbNkxDbK+LGH3/FEW5Au3iVr9i7f3rwoX8WewmFt/LaIR4E8f/RndC78O3hnH8uBEZivVnIcRAH9961hTL0S4YjUtDbG/Mvn/A19BeW79i7f3rQv4sHn9czL2XJzzEI78FXT1uTqKPOtVQjx8vIr24zR3/aXr5z9FxXCGwOvJRr6txOS51qO2N1fcvYgUD1Hxj7f3rSv4sHndcTL6X0Zqx+XzkG9thJdo4T0D7Zva4v9/jx5vIf5IkYKOiKM7If475Xe7vfH2Rj2539+jJXI02ZGrcGUx7Y/39g876KRwfWjH9/vVC/izG+HsZtVUMIx9vNhMZ7tP1CnDkvpVCiJWDOX48ifzwN/dy1wtCiCsjx3R7fZH/WB0/GMlo41jH5euDgdsby+9fh8j7uAlY0LNUEEvvX2RY4Aq00hBogftu17pwLP8s9vf6ToafRZBL0UqSJMU0uQCWJElSDJMhLkmSFMNkiEuSJMUwGeKSJEkxTIa4JElSDJMhLkmSFMNkiEuSJMUwGeKSJEkxTIa4JElSDPv/GL2GdOU6+IQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from scipy.optimize import curve_fit\n",
+    "\n",
+    "from diffprof.fit_nfw_helpers_lintime import get_loss_data, fit_lgconc\n",
+    "from diffprof.nfw_evolution_lintime import lgc_vs_t, DEFAULT_CONC_PARAMS\n",
+    "\n",
+    "from diffprof.fit_nfw_helpers_fixed_k import get_loss_data as get_loss_data_lgt, fit_lgconc as fit_lgconc_lgt\n",
+    "from diffprof.nfw_evolution import lgc_vs_lgt\n",
+    "\n",
+    "P_DEFAULT = np.array(list(DEFAULT_CONC_PARAMS.values()))\n",
+    "\n",
+    "ih = np.random.randint(0, len(sample))\n",
+    "p_guess = fit_lgconc(t_bpl, sample['conch_sim'][ih, :], sample['log_mah_fit'][ih, :], LGM_MIN_BPL)[0]\n",
+    "p_best, loss, method, loss_data = fit_lgconc(\n",
+    "    t_bpl, sample['conch_sim'][ih, :], sample['log_mah_fit'][ih, :], LGM_MIN_BPL, p0=np.array(p_guess))\n",
+    "xdata, ydata, msk = loss_data\n",
+    "\n",
+    "p_best_lgt, loss_lgt, method_lgt, loss_data_lgt = fit_lgconc_lgt(\n",
+    "    t_bpl, sample['conch_sim'][ih, :], sample['log_mah_fit'][ih, :], LGM_MIN_BPL)\n",
+    "xdata_lgt, ydata_lgt, msk_lgt = loss_data_lgt\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 1)\n",
+    "\n",
+    "__=ax.plot(t_bpl, sample['conch_sim'][ih, :])\n",
+    "__=ax.plot(xdata, 10**ydata)\n",
+    "\n",
+    "__=ax.plot(TARR, 10**lgc_vs_t(TARR, *p_guess), '--', color=mred)\n",
+    "__=ax.plot(TARR, 10**lgc_vs_t(TARR, *p_best), '--', color=mblue)\n",
+    "__=ax.plot(TARR, 10**lgc_vs_lgt(LGTARR, *p_best_lgt), '--', color=mgreen)\n",
+    "\n",
+    "tc_best, lgc_min, lgc_late = p_best\n",
+    "print(\"tc = {}\".format(tc_best))\n",
+    "print(\"c_min = {}\".format(10**lgc_min))\n",
+    "print(\"c_late = {}\".format(10**lgc_late))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "forward-funeral",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([0.7624159, 0.3045533, 1.2631224], dtype=float32)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p_guess"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "optical-examination",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Buffer([0.76241505, 0.30455264, 1.2631218 ], dtype=float32)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p_best"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "controlling-barrel",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/nfw_fitting_script_lintime.py
+++ b/scripts/nfw_fitting_script_lintime.py
@@ -5,8 +5,8 @@ from mpi4py import MPI
 import argparse
 from time import time
 from diffprof.load_bpl_histories import load_histories, TASSO, BEBOP
-from diffprof.nfw_evolution_lintime import get_outline, get_outline_bad_fit, get_header
-from diffprof.nfw_evolution_lintime import fit_lgconc
+from diffprof.fit_nfw_helpers_lintime import get_outline, get_outline_bad_fit
+from diffprof.fit_nfw_helpers_lintime import fit_lgconc, get_header
 import subprocess
 import h5py
 

--- a/scripts/nfw_fitting_script_lintime.py
+++ b/scripts/nfw_fitting_script_lintime.py
@@ -1,0 +1,104 @@
+"""Script to fit Bolshoi, MDPL2, or TNG MAHs with the diffmah model."""
+import numpy as np
+import os
+from mpi4py import MPI
+import argparse
+from time import time
+from diffprof.load_bpl_histories import load_histories, TASSO, BEBOP
+from diffprof.nfw_evolution_lintime import get_outline, get_outline_bad_fit, get_header
+from diffprof.nfw_evolution_lintime import fit_lgconc
+import subprocess
+import h5py
+
+TMP_OUTPAT = "_tmp_conc_fits_rank_{0}.dat"
+
+
+def _write_collated_data(outname, data):
+    nrows, ncols = np.shape(data)
+    colnames = get_header()[1:].strip().split()
+    assert len(colnames) == ncols, "data mismatched with header"
+    with h5py.File(outname, "w") as hdf:
+        for i, name in enumerate(colnames):
+            if name == "halo_id":
+                hdf[name] = data[:, i].astype("i8")
+            else:
+                hdf[name] = data[:, i]
+
+
+if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    rank, nranks = comm.Get_rank(), comm.Get_size()
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("outdir", help="Output directory")
+    parser.add_argument("outbase", help="Basename of the output hdf5 file")
+    parser.add_argument("-indir", help="Input directory", default="BEBOP")
+    parser.add_argument("-test", help="Short test run?", type=bool, default=False)
+
+    args = parser.parse_args()
+    rank_basepat = args.outbase + TMP_OUTPAT
+    rank_outname = os.path.join(args.outdir, rank_basepat).format(rank)
+
+    if args.indir == "TASSO":
+        indir = TASSO
+    elif args.indir == "BEBOP":
+        indir = BEBOP
+    else:
+        indir = args.indir
+    halo_ids, concs, log_mahs, t, LGM_MIN = load_histories(indir, "conc")
+
+    # Get data for rank
+    if args.test:
+        nhalos_tot = nranks * 25
+    else:
+        nhalos_tot = len(halo_ids)
+    _a = np.arange(0, nhalos_tot).astype("i8")
+    indx = np.array_split(_a, nranks)[rank]
+
+    halo_ids_for_rank = halo_ids[indx]
+    log_mahs_for_rank = log_mahs[indx]
+    concs_for_rank = concs[indx]
+    nhalos_for_rank = len(halo_ids_for_rank)
+
+    header = get_header()
+    start = time()
+    with open(rank_outname, "w") as fout:
+        fout.write(header)
+
+        for i in range(nhalos_for_rank):
+            halo_id = halo_ids_for_rank[i]
+            lgmah = log_mahs_for_rank[i, :]
+            conch = concs_for_rank[i, :]
+
+            p_best, loss, method, loss_data = fit_lgconc(t, conch, lgmah, LGM_MIN)
+
+            if np.isfinite(loss):
+                outline = get_outline(halo_id, p_best, loss, method)
+            else:
+                outline = get_outline_bad_fit(halo_id, p_best, loss, method)
+
+            fout.write(outline)
+
+    comm.Barrier()
+    end = time()
+
+    msg = (
+        "\n\nWallclock runtime to fit {0} galaxies with {1} ranks = {2:.1f} seconds\n\n"
+    )
+    if rank == 0:
+        runtime = end - start
+        print(msg.format(nhalos_tot, nranks, runtime))
+
+        #  collate data from ranks and rewrite to disk
+        pat = os.path.join(args.outdir, rank_basepat)
+        fit_data_fnames = [pat.format(i) for i in range(nranks)]
+        data_collection = [np.loadtxt(fn) for fn in fit_data_fnames]
+        all_fit_data = np.concatenate(data_collection)
+        outname = os.path.join(args.outdir, args.outbase)
+        _write_collated_data(outname, all_fit_data)
+
+        #  clean up temporary files
+        _remove_basename = pat.replace("{0}", "*")
+        command = "rm -rf " + _remove_basename
+        raw_result = subprocess.check_output(command, shell=True)


### PR DESCRIPTION
This PR brings in an alternative model for the concentration evolution of individual halos, in which log(conc) ~ t, rather than logt like the current model. The standard diagnostic plot of the residuals comparable to the current model, and I have not really tried to tune the ranges or the value of k, so I think this alternative model has potential to be just as accurate as the current one. 

![residual_lintime_vs_logtime](https://user-images.githubusercontent.com/6951595/132747858-9eb8fdb6-eb5d-45bb-b368-e080d36fb9d7.png)

The motivation for this alternative model for the individual c(t) is that it may be simpler to use this as the basis of the population model. Currently, @dash-vich has been struggling to find a high-accuracy fit to the concentration histories of halo populations. But the target data model itself is based on a logc-t relationship, so we may find that if we switched up our model for individual c(t) to this alternative, that we'd get improved results for the population model.


