### PR TITLE
Resolved test failure due to lack of unbounded grid density

### DIFF
--- a/diffprof/nfw_evolution.py
+++ b/diffprof/nfw_evolution.py
@@ -11,6 +11,7 @@ from jax import numpy as jnp
 CONC_MIN = 2.0
 LGC_LOG10_CLIP = jnp.log10(jnp.log10(CONC_MIN))
 _X0, _K = 0.0, 0.1
+_K_lgtcbl = 0.01
 
 DEFAULT_CONC_PARAMS = OrderedDict(
     conc_lgtc=0.8, conc_k=5.0, conc_beta_early=0.35, conc_beta_late=1.2
@@ -101,12 +102,12 @@ def get_unbounded_params(params):
 
 @jjit
 def _get_lgtc(u_conc_lgtc):
-    return _sigmoid(u_conc_lgtc, _X0, _K, *CONC_PARAM_BOUNDS["conc_lgtc"])
+    return _sigmoid(u_conc_lgtc, _X0, _K_lgtcbl, *CONC_PARAM_BOUNDS["conc_lgtc"])
 
 
 @jjit
 def _get_u_lgtc(conc_lgtc):
-    return _inverse_sigmoid(conc_lgtc, _X0, _K, *CONC_PARAM_BOUNDS["conc_lgtc"])
+    return _inverse_sigmoid(conc_lgtc, _X0, _K_lgtcbl, *CONC_PARAM_BOUNDS["conc_lgtc"])
 
 
 @jjit
@@ -134,13 +135,13 @@ def _get_u_beta_early(conc_beta_early):
 @jjit
 def _get_beta_late(u_conc_beta_late, conc_beta_early):
     ylo, yhi = conc_beta_early, CONC_PARAM_BOUNDS["conc_beta_late"][1]
-    return _sigmoid(u_conc_beta_late, _X0, _K, ylo, yhi)
+    return _sigmoid(u_conc_beta_late, _X0, _K_lgtcbl, ylo, yhi)
 
 
 @jjit
 def _get_u_beta_late(conc_beta_late, conc_beta_early):
     ylo, yhi = conc_beta_early, CONC_PARAM_BOUNDS["conc_beta_late"][1]
-    return _inverse_sigmoid(conc_beta_late, _X0, _K, ylo, yhi)
+    return _inverse_sigmoid(conc_beta_late, _X0, _K_lgtcbl, ylo, yhi)
 
 
 @jjit

--- a/diffprof/tests/test_mc_diffprofpop.py
+++ b/diffprof/tests/test_mc_diffprofpop.py
@@ -39,7 +39,7 @@ def test_mc_diffprofpop_is_consistent_with_dpp_predictions():
     singlemass_dpp_params = get_singlemass_params_p50(lgm0)
 
     p50_arr = np.linspace(0, 1, 50)
-    u_param_grids = get_u_param_grids(ran_key, 300)
+    u_param_grids = get_u_param_grids(ran_key, 3000)
     u_be_grid, u_lgtc_bl_grid = u_param_grids
     args = (singlemass_dpp_params, tarr, p50_arr, u_be_grid, u_lgtc_bl_grid)
     dpp_preds = get_predictions_from_singlemass_params_p50(*args)


### PR DESCRIPTION
Created `_K_lgtcbl` value in `nfw_evolution.py` to reduce the transition rate of the bounding/unbounding sigmoid transform for `lgtc` and `bl` and then increasing the sampling density of the latin hypercube from 300 points to 3,000 points in the differentiable implementation of the model for the MC versus differentiable test in `tests/test_mc_diffprofpop.py` which causes this test to go from failing to passing while leaving all other passing tests passing.