### PR TITLE
Fix bug in the get_conc_param_p50_pop_grids function 

### DIFF
--- a/diffprof/diffprofpop_p50_dependence.py
+++ b/diffprof/diffprofpop_p50_dependence.py
@@ -335,7 +335,7 @@ def lgc_pop_vs_lgt_and_p50(lgt, p50_arr, be_grid, lgtc_bl_grid, conc_k):
 @jjit
 def get_conc_param_p50_pop_grids(p50_arr, be_grid, lgtc_bl_grid, conc_k):
     n_p50, n_grid = p50_arr.size, be_grid.size
-    be_p50_pop = jnp.tile(be_grid, n_p50).reshape((n_grid, n_p50))
+    be_p50_pop = jnp.repeat(be_grid, n_p50).reshape((n_grid, n_p50))
     lgtc_grid = lgtc_bl_grid[:, 0]
     bl_grid = lgtc_bl_grid[:, 1]
     lgtc_p50_pop = jnp.repeat(lgtc_grid, n_p50).reshape((n_grid, n_p50))


### PR DESCRIPTION
The get_conc_param_p50_pop_grids function is responsible for transforming an input grid of concentration trajectory parameters into the appropriate form that is ingested by the c(t) trajectory model. This function had a bug in it - one of the parameter grids was incorrectly transposed relative to the others. Changing this one line of code resolves the long-standing discrepancy between the Monte Carlo realizations and the differentiable prediction pipeline.

In the recent PR #24, I suggested that we needed to overhaul our prediction pipeline so that each value of p50 received its own tailored grid. I am now fairly close to finishing up that overhaul, and I still think that the overhaul will result in higher-accuracy predictions at fixed computational cost, but in light of this PR it is unclear to me whether those changes are necessary in order to finish calibrating the model. I will study this carefully and report results once I have them.

cc @dash-vich @dnagai76 